### PR TITLE
added option to use query strings to filter results from codes API

### DIFF
--- a/reports-api/src/reports_api/resources/code.py
+++ b/reports-api/src/reports_api/resources/code.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Resource for code endpoints."""
 from http import HTTPStatus
+from flask import request
 
 from flask_restx import Namespace, Resource, cors
 
@@ -34,10 +35,11 @@ class Codes(Resource):
     @cors.crossdomain(origin='*')
     @auth.require
     @profiletime
-    @AppCache.cache.cached(timeout=constants.CACHE_DAY_TIMEOUT)
+    @AppCache.cache.cached(timeout=constants.CACHE_DAY_TIMEOUT, query_string=True)
     def get(code_type):
         """Return all codes based on code_type."""
-        return CodeService.find_code_values_by_type(code_type), HTTPStatus.OK
+        filters = dict(request.args)
+        return CodeService.find_code_values_by_type(code_type, filters), HTTPStatus.OK
 
 
 @cors_preflight('GET')

--- a/reports-api/src/reports_api/services/code.py
+++ b/reports-api/src/reports_api/services/code.py
@@ -26,8 +26,8 @@ class CodeService:
     def find_code_values_by_type(
             cls,
             code_type: str,
-            filters: dict
-    ):
+            filters: dict = {}
+    ):  # pylint: disable=dangerous-default-value
         """Find code values by code type."""
         current_app.logger.debug(f'<find_code_values_by_type : {code_type}')
         model: CodeTable = find_model_from_table_name(code_type)

--- a/reports-api/src/reports_api/services/code.py
+++ b/reports-api/src/reports_api/services/code.py
@@ -25,13 +25,14 @@ class CodeService:
     @classmethod
     def find_code_values_by_type(
             cls,
-            code_type: str
+            code_type: str,
+            filters: dict
     ):
         """Find code values by code type."""
         current_app.logger.debug(f'<find_code_values_by_type : {code_type}')
         model: CodeTable = find_model_from_table_name(code_type)
         response = {'codes': []}
-        for row in model.find_all():
+        for row in model.query.filter_by(**filters):
             response['codes'].append(row.as_dict())
 
         current_app.logger.debug('>find_code_values_by_type')

--- a/reports-api/src/reports_api/services/staff.py
+++ b/reports-api/src/reports_api/services/staff.py
@@ -35,7 +35,7 @@ class StaffService:
 
     @classmethod
     def find_by_position_ids(cls, position_ids):
-        """Find staff by position."""
+        """Find staffs by position ids."""
         current_app.logger.debug(f'Find staff by positions : {position_ids}')
 
         response = {'staffs': []}


### PR DESCRIPTION
usage example
  - `/api/v1/codes/regions?entity=ENV` -  will return all regions where `entity == ENV`
  - `/api/v1/codes/regions?entity=FLNR` -  will return all regions where `entity == FLNR`