### PR TITLE
792 - Custom no-result found message

### DIFF
--- a/epictrack-web/src/App.tsx
+++ b/epictrack-web/src/App.tsx
@@ -5,6 +5,7 @@ import UserService from "./services/userService";
 import AuthenticatedRoutes from "./routes/AuthenticatedRoutes";
 import { useAppDispatch, useAppSelector } from "./hooks";
 import { Box, Theme, useMediaQuery } from "@mui/material";
+import AxiosErrorHandler from "./components/axiosErrorHandler/AxiosErrorHandler";
 import "./styles/App.scss";
 
 export default function App() {
@@ -22,25 +23,27 @@ export default function App() {
   }, [dispatch]);
   return (
     <>
-      {isLoggedIn && (
-        <Router>
-          <Box sx={{ display: "flex" }}>
-            <Header />
-            <Box
-              component="main"
-              sx={{
-                flexGrow: 1,
-                width: `calc(100% - ${drawerWidth}px)`,
-                marginTop: "17px",
-              }}
-            >
-              <React.StrictMode>
-                <AuthenticatedRoutes />
-              </React.StrictMode>
+      <AxiosErrorHandler>
+        {isLoggedIn && (
+          <Router>
+            <Box sx={{ display: "flex" }}>
+              <Header />
+              <Box
+                component="main"
+                sx={{
+                  flexGrow: 1,
+                  width: `calc(100% - ${drawerWidth}px)`,
+                  marginTop: "17px",
+                }}
+              >
+                <React.StrictMode>
+                  <AuthenticatedRoutes />
+                </React.StrictMode>
+              </Box>
             </Box>
-          </Box>
-        </Router>
-      )}
+          </Router>
+        )}
+      </AxiosErrorHandler>
     </>
   );
 }

--- a/epictrack-web/src/components/axiosErrorHandler/AxiosErrorHandler.tsx
+++ b/epictrack-web/src/components/axiosErrorHandler/AxiosErrorHandler.tsx
@@ -1,0 +1,46 @@
+import { useEffect } from "react";
+import axios from "axios";
+
+const AxiosErrorHandler = ({ ...props }) => {
+  useEffect(() => {
+    // Request interceptor
+    const requestInterceptor = axios.interceptors.request.use((request) => {
+      // Do something here with request if you need to
+      return request;
+    });
+
+    // Response interceptor
+    const responseInterceptor = axios.interceptors.response.use(
+      (response) => {
+        // Handle response here
+        return response;
+      },
+      (error) => {
+        // Handle errors here
+        if (error.response?.status) {
+          switch (error.response.status) {
+            case 401:
+              // Handle Unauthenticated here
+              break;
+            case 403:
+              // Handle Unauthorized here
+              break;
+            // ... And so on
+          }
+        }
+
+        return error;
+      }
+    );
+
+    return () => {
+      // Remove handlers here
+      axios.interceptors.request.eject(requestInterceptor);
+      axios.interceptors.response.eject(responseInterceptor);
+    };
+  }, []);
+
+  return props.children;
+};
+
+export default AxiosErrorHandler;

--- a/epictrack-web/src/components/shared/MasterTrackTable.tsx
+++ b/epictrack-web/src/components/shared/MasterTrackTable.tsx
@@ -11,51 +11,40 @@ const NoDataComponent = ({ ...props }) => {
   const { table } = props;
   return (
     <>
-      {table.options.data.length == 0 ? (
-        <Typography
-          sx={{
-            color: "text.secondary",
-            py: "2rem",
-            textAlign: "center",
-            width: "100%",
-          }}
-        >
-          No results found
-        </Typography>
-      ) : (
-        <Container
+      <Container
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          minHeight: "400px",
+        }}
+      >
+        <Box
           sx={{
             display: "flex",
+            flexDirection: "column",
+            gap: "2rem",
             alignItems: "center",
-            justifyContent: "center",
-            minHeight: "400px",
           }}
         >
+          <Box component="img" src={SearchIcon} alt="Search" width="32px" />
           <Box
             sx={{
               display: "flex",
               flexDirection: "column",
-              gap: "2rem",
+              gap: "1rem",
               alignItems: "center",
             }}
           >
-            <Box component="img" src={SearchIcon} alt="Search" width="32px" />
-            <Box
-              sx={{
-                display: "flex",
-                flexDirection: "column",
-                gap: "1rem",
-                alignItems: "center",
-              }}
-            >
-              <ETHeading2 bold>No results found</ETHeading2>
+            <ETHeading2 bold>No results found</ETHeading2>
+            {table.options.data.length > 0 && (
               <Typography color="#6D7274">
                 Adjust your parameters and try again
               </Typography>
-            </Box>
+            )}
           </Box>
-        </Container>
-      )}
+        </Box>
+      </Container>
     </>
   );
 };

--- a/epictrack-web/src/components/shared/MasterTrackTable.tsx
+++ b/epictrack-web/src/components/shared/MasterTrackTable.tsx
@@ -3,7 +3,62 @@ import MaterialReactTable, {
   MRT_ToggleFiltersButton,
   MaterialReactTableProps,
 } from "material-react-table";
+import { Box, Container, Typography } from "@mui/material";
+import SearchIcon from "../../assets/images/search.svg";
+import { ETHeading2 } from ".";
 
+const NoDataComponent = ({ ...props }) => {
+  const { table } = props;
+  return (
+    <>
+      {table.options.data.length == 0 ? (
+        <Typography
+          sx={{
+            color: "text.secondary",
+            py: "2rem",
+            textAlign: "center",
+            width: "100%",
+          }}
+        >
+          No results found
+        </Typography>
+      ) : (
+        <Container
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            minHeight: "400px",
+          }}
+        >
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "2rem",
+              alignItems: "center",
+            }}
+          >
+            <Box component="img" src={SearchIcon} alt="Search" width="32px" />
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "column",
+                gap: "1rem",
+                alignItems: "center",
+              }}
+            >
+              <ETHeading2 bold>No results found</ETHeading2>
+              <Typography color="#6D7274">
+                Adjust your parameters and try again
+              </Typography>
+            </Box>
+          </Box>
+        </Container>
+      )}
+    </>
+  );
+};
 const MasterTrackTable = <T extends Record<string, any>>({
   columns,
   data,
@@ -62,6 +117,9 @@ const MasterTrackTable = <T extends Record<string, any>>({
           columnPinning: { right: ["mrt-row-actions"] },
           ...rest.state,
         }}
+        renderEmptyRowsFallback={({ table }) => (
+          <NoDataComponent table={table} />
+        )}
       />
     </>
   );

--- a/reports-api/src/reports_api/__init__.py
+++ b/reports-api/src/reports_api/__init__.py
@@ -61,6 +61,8 @@ def create_app(run_mode=os.getenv('FLASK_ENV', 'production')):
         def add_version(response):  # pylint: disable=unused-variable
             version = get_run_version()
             response.headers['API'] = f'eao_reports_api/{version}'
+            # So that ERR responses don't raise CORS error in browser
+            response.headers['Access-Control-Allow-Origin'] = '*'
             return response
 
         @app.errorhandler(Exception)

--- a/reports-api/src/reports_api/resources/staff.py
+++ b/reports-api/src/reports_api/resources/staff.py
@@ -135,4 +135,4 @@ class StaffByEmail(Resource):
         staff = StaffService.find_by_email(email)
         if staff:
             return res.StaffResponseSchema().dump(staff), HTTPStatus.OK
-        raise ResourceNotFoundError(f'Staff with id "{email}" not found')
+        raise ResourceNotFoundError(f'Staff with email "{email}" not found')


### PR DESCRIPTION
#792 - Custom no-result found message

- updated reports-api to append CORS headers with error response also.
- added an AxiosErrorHandler component to avoid epic track showing blank/white page when API request fails

1. When no data after filters applied
![image](https://github.com/bcgov/EPIC.track/assets/85282214/3310e56c-1335-4077-ab8b-615ac628093c)

2. When no data available in database
![image](https://github.com/bcgov/EPIC.track/assets/85282214/6a8e8598-33fa-4d61-9e19-e02e0b663fda)

