### PR TITLE
878

### DIFF
--- a/epictrack-web/src/components/shared/notificationProvider/components/ETNotification.tsx
+++ b/epictrack-web/src/components/shared/notificationProvider/components/ETNotification.tsx
@@ -74,14 +74,32 @@ const useStyles = makeStyles({
 
 const ETNotification = React.forwardRef<HTMLDivElement, ETNotificationProps>(
   (props, ref) => {
-    const { id, message, type, helpText, actions, iconVariant, ...other } =
-      props;
+    const {
+      id,
+      message,
+      type,
+      helpText: HelpText,
+      actions,
+      iconVariant,
+      ...other
+    } = props;
     const { closeSnackbar } = useSnackbar();
     const classes = useStyles();
 
     const handleDismiss = React.useCallback(() => {
       closeSnackbar(id);
     }, [id, closeSnackbar]);
+
+    const helpTextComponent = React.useMemo(() => {
+      return (
+        React.isValidElement(HelpText) ? (
+          // { helpText }
+          HelpText
+        ) : (
+          <Typography>{HelpText}</Typography>
+        )
+      ) as React.ReactElement;
+    }, [HelpText]);
 
     return (
       <SnackbarContent
@@ -93,7 +111,7 @@ const ETNotification = React.forwardRef<HTMLDivElement, ETNotificationProps>(
           [classes.warning]: type === "warning",
           [classes.error]: type === "error",
           [classes.info]: type === "info",
-          [classes.withTitle]: Boolean(helpText),
+          [classes.withTitle]: Boolean(HelpText),
         })}
       >
         <Box className={classes.header}>
@@ -107,9 +125,9 @@ const ETNotification = React.forwardRef<HTMLDivElement, ETNotificationProps>(
             <CloseIconComponent />
           </IconButton>
         </Box>
-        {(helpText || actions) && (
+        {(HelpText || actions) && (
           <Box className={classes.content}>
-            <Typography>{helpText}</Typography>
+            {helpTextComponent}
             {actions && actions.length > 0 && (
               <Box className={classes.actions}>
                 {actions?.map((action) => (

--- a/epictrack-web/src/components/shared/notificationProvider/index.ts
+++ b/epictrack-web/src/components/shared/notificationProvider/index.ts
@@ -1,5 +1,6 @@
 import { SnackbarMessage, enqueueSnackbar } from "notistack";
 import { CustomAction, NotificationOptions } from "./type";
+import React from "react";
 
 export const showNotification = (
   title: SnackbarMessage,
@@ -61,7 +62,7 @@ declare module "notistack" {
   interface VariantOverrides {
     etNotification: {
       type: string;
-      helpText?: string;
+      helpText?: string | React.ReactElement;
       actions?: CustomAction[];
     };
   }

--- a/epictrack-web/src/components/shared/notificationProvider/type.ts
+++ b/epictrack-web/src/components/shared/notificationProvider/type.ts
@@ -1,4 +1,5 @@
 import { CustomContentProps } from "notistack";
+import React from "react";
 
 export interface CustomAction {
   label: string;
@@ -9,7 +10,7 @@ export interface CustomAction {
 export interface NotificationOptions {
   type: "success" | "warning" | "error" | "info";
   duration?: number | null;
-  message?: string;
+  message?: string | React.ReactElement;
   actions?: CustomAction[];
 }
 

--- a/reports-api/src/reports_api/services/task.py
+++ b/reports-api/src/reports_api/services/task.py
@@ -44,6 +44,10 @@ class TaskService:
         task_event = task_event.flush()
         if data.get("assignee_ids"):
             cls._handle_assignees(data.get("assignee_ids"), task_event)
+        work_phase = WorkPhaseService.find_by_work_nd_phase(
+            data.get("work_id"), data.get("phase_id")
+        )
+        work_phase.template_uploaded = True
         if commit:
             db.session.commit()
         return task_event


### PR DESCRIPTION
 - Show phase name in the template available alert
 - Disable import template button if no template available
 - Mark template uploaded as true when a task is added
 - Hide template available alert, when
   - Expanding a different phase accordion
   - Switching tabs in work plan page
   - Switching to a different page