### PR TITLE
Inactive projects not included on list management - projects page

### DIFF
--- a/reports-api/src/reports_api/services/project.py
+++ b/reports-api/src/reports_api/services/project.py
@@ -30,7 +30,7 @@ class ProjectService:
     @classmethod
     def find_all(cls):
         """Find all projects"""
-        return Project.find_all()
+        return Project.find_all(default_filters=False)
 
     @classmethod
     def create_project(cls, payload: dict):


### PR DESCRIPTION
When in projects tab of list management and you try to search for a project that is inactive, or try to use the filters to only view inactive projects they will not show.
#1007 