### PR TITLE
Fixed create staff modal from autofilling after editing a staff member

### DIFF
--- a/epictrack-web/src/components/shared/MasterContext.tsx
+++ b/epictrack-web/src/components/shared/MasterContext.tsx
@@ -134,6 +134,7 @@ export const MasterProvider = ({
             showNotification(`${title} details updated`, {
               type: "success",
             });
+            setItem(undefined);
             setBackdrop(false);
             callback();
           }


### PR DESCRIPTION
Reproduce bug in develop: Edit staff member -> Click save -> Click create staff
#992 