### PR TITLE
Fix how lazy loading is triggered

### DIFF
--- a/epictrack-web/src/components/myWorkplans/CardList.tsx
+++ b/epictrack-web/src/components/myWorkplans/CardList.tsx
@@ -5,16 +5,16 @@ import { useContext } from "react";
 import { MyWorkplansContext } from "./MyWorkPlanContext";
 import { CardListSkeleton } from "./CardListSkeleton";
 import { Unless } from "react-if";
-import { throttle } from "lodash";
 import TriggerOnViewed from "../shared/DummyElement";
 
 const CardList = () => {
-  const { workplans, loadingWorkplans, totalWorkplans, lazyLoadMoreWorkplans } =
-    useContext(MyWorkplansContext);
-
-  const throttledLazyLoadWorkplans = throttle(() => {
-    lazyLoadMoreWorkplans();
-  }, 5000);
+  const {
+    workplans,
+    loadingWorkplans,
+    totalWorkplans,
+    loadingMoreWorkplans,
+    setLoadingMoreWorkplans,
+  } = useContext(MyWorkplansContext);
 
   if (loadingWorkplans) {
     return (
@@ -38,9 +38,18 @@ const CardList = () => {
         );
       })}
       <Unless
-        condition={loadingWorkplans || workplans.length === totalWorkplans}
+        condition={
+          loadingWorkplans ||
+          loadingMoreWorkplans ||
+          workplans.length === totalWorkplans
+        }
       >
-        <TriggerOnViewed callbackFn={throttledLazyLoadWorkplans} />
+        <TriggerOnViewed
+          callbackFn={() => {
+            console.log("triggered");
+            setLoadingMoreWorkplans(true);
+          }}
+        />
       </Unless>
       <Unless condition={workplans.length === totalWorkplans}>
         <CardListSkeleton />

--- a/epictrack-web/src/components/myWorkplans/MyWorkPlanContext.tsx
+++ b/epictrack-web/src/components/myWorkplans/MyWorkPlanContext.tsx
@@ -9,7 +9,8 @@ interface MyWorkplanContextProps {
   lazyLoadMoreWorkplans: () => any;
   totalWorkplans: number;
   setSearchOptions: React.Dispatch<React.SetStateAction<WorkPlanSearchOptions>>;
-  loadingMoreWorkplans?: boolean;
+  loadingMoreWorkplans: boolean;
+  setLoadingMoreWorkplans: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export const MyWorkplansContext = createContext<MyWorkplanContextProps>({
@@ -23,6 +24,9 @@ export const MyWorkplansContext = createContext<MyWorkplanContextProps>({
     return;
   },
   loadingMoreWorkplans: false,
+  setLoadingMoreWorkplans: () => {
+    return;
+  },
 });
 
 export interface WorkPlanSearchOptions {
@@ -101,6 +105,12 @@ export const MyWorkplansProvider = ({
     loadWorkplans();
   }, [searchOptions]);
 
+  useEffect(() => {
+    if (loadingMoreWorkplans) {
+      lazyLoadMoreWorkplans();
+    }
+  }, [loadingMoreWorkplans]);
+
   return (
     <MyWorkplansContext.Provider
       value={{
@@ -110,6 +120,7 @@ export const MyWorkplansProvider = ({
         totalWorkplans,
         setSearchOptions,
         loadingMoreWorkplans,
+        setLoadingMoreWorkplans,
       }}
     >
       {children}


### PR DESCRIPTION
https://app.zenhub.com/workspaces/epictrack-63891ea941d309001fa292cf/issues/gh/bcgov/epic.track/1493

Details:
- Hide trigger on view component when lazy loading is happening
- trigger the lazy loading indirectly using the useEffect and setting loading state