### PR TITLE
Use reusable date picker component

### DIFF
--- a/epictrack-web/src/components/reports/shared/report-header/ReportHeader.tsx
+++ b/epictrack-web/src/components/reports/shared/report-header/ReportHeader.tsx
@@ -4,6 +4,7 @@ import { DatePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { DATE_FORMAT } from "../../../../constants/application-constant";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { dateUtils } from "../../../../utils";
+import TrackDatePicker from "../../../shared/DatePicker";
 
 const ReportHeader = ({ ...props }) => {
   const STALE_DATE_BANNER =
@@ -21,19 +22,16 @@ const ReportHeader = ({ ...props }) => {
           <FormLabel>Report Date</FormLabel>
         </Grid>
         <Grid item sm={2}>
-          <LocalizationProvider dateAdapter={AdapterDayjs}>
-            <DatePicker
-              format={DATE_FORMAT}
-              onChange={(dateVal: any) =>
-                props.setReportDate(dateUtils.formatDate(dateVal.$d))
-              }
-              slotProps={{
-                textField: {
-                  id: "ReportDate",
-                },
-              }}
-            />
-          </LocalizationProvider>
+          <TrackDatePicker
+            onChange={(dateVal: any) =>
+              props.setReportDate(dateUtils.formatDate(dateVal.$d))
+            }
+            slotProps={{
+              textField: {
+                id: "ReportDate",
+              },
+            }}
+          />
         </Grid>
         <Grid item sm={4}></Grid>
         <Grid item sm={2}>

--- a/epictrack-web/src/components/shared/controlledInputComponents/ControlledSelectV2.tsx
+++ b/epictrack-web/src/components/shared/controlledInputComponents/ControlledSelectV2.tsx
@@ -41,8 +41,9 @@ const ControlledSelectV2: React.ForwardRefRenderFunction<
       control={control}
       name={name}
       defaultValue={defaultValues?.[name] || ""}
-      render={({ field }) => {
+      render={({ field, fieldState }) => {
         const { onChange, value } = field;
+        const { error } = fieldState;
         return (
           <TrackSelect
             placeholder={placeholder}
@@ -67,8 +68,8 @@ const ControlledSelectV2: React.ForwardRefRenderFunction<
               if (onHandleChange !== undefined) onHandleChange(v);
               return onChange(v);
             }}
-            error={!!errors[name]}
-            helperText={String(errors[name]?.message) || helperText}
+            error={!!error}
+            helperText={String(error?.message) || helperText}
           />
         );
       }}

--- a/epictrack-web/src/components/shared/controlledInputComponents/ControlledTextField.tsx
+++ b/epictrack-web/src/components/shared/controlledInputComponents/ControlledTextField.tsx
@@ -4,6 +4,7 @@ import { Controller, useFormContext } from "react-hook-form";
 
 type IFormInputProps = {
   name: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   inputEffects?: (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => string;
@@ -12,6 +13,7 @@ type IFormInputProps = {
 const ControlledTextField: FC<IFormInputProps> = ({
   name,
   inputEffects,
+  onChange: onInputChange,
   ...otherProps
 }) => {
   const {
@@ -29,6 +31,9 @@ const ControlledTextField: FC<IFormInputProps> = ({
           {...field}
           {...otherProps}
           onChange={(e) => {
+            if (onInputChange) {
+              onInputChange(e);
+            }
             if (inputEffects) {
               e.target.value = inputEffects(e);
             }

--- a/epictrack-web/src/components/workPlan/event/components/ExtensionInput.tsx
+++ b/epictrack-web/src/components/workPlan/event/components/ExtensionInput.tsx
@@ -11,6 +11,7 @@ import { dateUtils } from "../../../../utils";
 import { SyntheticEvent } from "react-draft-wysiwyg";
 import { ETFormLabel } from "../../../shared";
 import ExtensionSuspensionInput from "./ExtensionSuspensionInput";
+import ControlledDatePicker from "../../../shared/controlledInputComponents/ControlledDatePicker";
 
 interface ExtensionInputProps {
   isFormFieldsLocked: boolean;
@@ -106,34 +107,19 @@ const ExtensionInput = (props: ExtensionInputProps) => {
       </Grid>
       <Grid item xs={6}>
         <ETFormLabel required>End Date</ETFormLabel>
-        <Controller
+        <ControlledDatePicker
           name="phase_end_date"
-          control={control}
-          render={({ field: { onChange, value }, fieldState: { error } }) => (
-            <LocalizationProvider dateAdapter={AdapterDayjs}>
-              <DatePicker
-                disabled={props.isFormFieldsLocked}
-                format={DATE_FORMAT}
-                slotProps={{
-                  textField: {
-                    fullWidth: true,
-                    inputRef: endDateRef,
-                    error: error ? true : false,
-                    helperText: error?.message,
-                    placeholder: "MM-DD-YYYY",
-                  },
-                  ...register("phase_end_date"),
-                }}
-                value={dayjs(value)}
-                onChange={(event: any) => {
-                  const d = event ? event["$d"] : null;
-                  onChange(d);
-                  onEndDateChange(d);
-                }}
-                sx={{ display: "block" }}
-              />
-            </LocalizationProvider>
-          )}
+          datePickerProps={{
+            disabled: props.isFormFieldsLocked,
+            onDateChange: (event: any, defaultOnChange: any) => {
+              const d = event ? event["$d"] : null;
+              defaultOnChange(d);
+              onEndDateChange(d);
+            },
+          }}
+          datePickerSlotProps={{
+            inputRef: endDateRef,
+          }}
         />
       </Grid>
       <ExtensionSuspensionInput isFormFieldsLocked={props.isFormFieldsLocked} />

--- a/epictrack-web/src/components/workPlan/status/StatusForm.tsx
+++ b/epictrack-web/src/components/workPlan/status/StatusForm.tsx
@@ -1,21 +1,21 @@
 import React, { useContext, useRef } from "react";
-import { Controller, FormProvider, useForm } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
 import * as yup from "yup";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { Grid, TextField } from "@mui/material";
 import { ETFormLabel, ETFormLabelWithCharacterLimit } from "../../shared";
-import { LocalizationProvider, DatePicker } from "@mui/x-date-pickers";
-import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import dayjs from "dayjs";
-import {
-  DATE_FORMAT,
-  EARLIEST_WORK_DATE,
-} from "../../../constants/application-constant";
+import { EARLIEST_WORK_DATE } from "../../../constants/application-constant";
 import Moment from "moment";
 import { StatusContext } from "./StatusContext";
 import { WorkplanContext } from "../WorkPlanContext";
+import ControlledDatePicker from "../../shared/controlledInputComponents/ControlledDatePicker";
+import ControlledTextField from "../../shared/controlledInputComponents/ControlledTextField";
 
-const schema = yup.object().shape({});
+const schema = yup.object().shape({
+  posted_date: yup.string().required("Date is required"),
+  description: yup.string().required("Description is required"),
+});
 const CHARACTER_LIMIT = 500;
 
 const StatusForm = () => {
@@ -53,13 +53,7 @@ const StatusForm = () => {
     mode: "onBlur",
   });
 
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-    reset,
-    control,
-  } = methods;
+  const { handleSubmit, reset } = methods;
 
   const handleDescriptionChange = (event: any) => {
     setDescription(event.target.value);
@@ -84,40 +78,18 @@ const StatusForm = () => {
         }}
         onSubmit={handleSubmit(onSubmitHandler)}
       >
-        <Grid item xs={4}>
+        <Grid item xs={5}>
           <ETFormLabel required>Date</ETFormLabel>
-          <Controller
+          <ControlledDatePicker
             name="posted_date"
-            control={control}
-            defaultValue={Moment(status?.posted_date).format()}
-            render={({ field: { onChange, value }, fieldState: { error } }) => (
-              <LocalizationProvider dateAdapter={AdapterDayjs}>
-                <DatePicker
-                  minDate={postedDateMin}
-                  maxDate={postedDateMax}
-                  format={DATE_FORMAT}
-                  slotProps={{
-                    textField: {
-                      id: "start_date",
-                      fullWidth: true,
-                      inputRef: startDateRef,
-                      error: error ? true : false,
-                      helperText: error?.message,
-                      placeholder: "MM-DD-YYYY",
-                    },
-                    ...register("posted_date"),
-                  }}
-                  value={dayjs(value)}
-                  onChange={(event) => {
-                    onChange(event);
-                  }}
-                  defaultValue={dayjs(
-                    status?.posted_date ? status?.posted_date : ""
-                  )}
-                  sx={{ display: "block" }}
-                />
-              </LocalizationProvider>
-            )}
+            defaultValue={dayjs(status?.posted_date ? status?.posted_date : "")}
+            datePickerProps={{
+              minDate: postedDateMin,
+              maxDate: postedDateMax,
+            }}
+            datePickerSlotProps={{
+              inputRef: startDateRef,
+            }}
           />
         </Grid>
         <Grid item xs={12}>
@@ -128,14 +100,12 @@ const StatusForm = () => {
           >
             Description
           </ETFormLabelWithCharacterLimit>
-          <TextField
-            fullWidth
+          <ControlledTextField
+            name="description"
             multiline
             rows={4}
-            {...register("description")}
-            error={!!errors?.description?.message}
-            helperText={errors?.description?.message?.toString()}
             onChange={handleDescriptionChange}
+            fullWidth
             inputProps={{
               maxLength: CHARACTER_LIMIT,
             }}

--- a/epictrack-web/src/components/workPlan/task/TaskForm.tsx
+++ b/epictrack-web/src/components/workPlan/task/TaskForm.tsx
@@ -1,12 +1,9 @@
 import React, { useState, useContext, useRef, useEffect, useMemo } from "react";
-import { Controller, FormProvider, useForm } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
 import * as yup from "yup";
 import { yupResolver } from "@hookform/resolvers/yup";
-import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
-import { DatePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import Moment from "moment";
-import { DATE_FORMAT } from "../../../constants/application-constant";
-import { Grid, TextField } from "@mui/material";
+import { Grid } from "@mui/material";
 import { ETFormLabel } from "../../shared";
 import { TaskEvent, statusOptions } from "../../../models/taskEvent";
 import dayjs from "dayjs";
@@ -25,6 +22,9 @@ import { EVENT_TYPE } from "../phase/type";
 import { EventContext } from "../event/EventContext";
 import ControlledMultiSelect from "../../shared/controlledInputComponents/ControlledMultiSelect";
 import { getErrorMessage } from "../../../utils/axiosUtils";
+import ControlledDatePicker from "../../shared/controlledInputComponents/ControlledDatePicker";
+import TrackDatePicker from "../../shared/DatePicker";
+import ControlledTextField from "../../shared/controlledInputComponents/ControlledTextField";
 
 const schema = yup.object().shape({
   name: yup.string().required("Name is required"),
@@ -66,7 +66,6 @@ const TaskForm = ({
     handleSubmit,
     formState: { errors },
     reset,
-    control,
     setValue,
   } = methods;
 
@@ -219,57 +218,34 @@ const TaskForm = ({
           >
             <Grid item xs={12}>
               <ETFormLabel required>Title</ETFormLabel>
-              <TextField
-                fullWidth
+              <ControlledTextField
+                name="name"
                 placeholder="Title"
                 defaultValue={taskEvent?.name}
-                error={!!errors?.name?.message}
-                helperText={errors?.name?.message?.toString()}
-                {...register("name")}
+                fullWidth
               />
             </Grid>
             <Grid item xs={4}>
               <ETFormLabel>Start Date</ETFormLabel>
-              <Controller
+              <ControlledDatePicker
                 name="start_date"
-                control={control}
                 defaultValue={Moment(taskEvent?.start_date).format()}
-                render={({
-                  field: { onChange, value },
-                  fieldState: { error },
-                }) => (
-                  <LocalizationProvider dateAdapter={AdapterDayjs}>
-                    <DatePicker
-                      format={DATE_FORMAT}
-                      slotProps={{
-                        textField: {
-                          id: "start_date",
-                          fullWidth: true,
-                          inputRef: startDateRef,
-                          error: error ? true : false,
-                          helperText: error?.message,
-                          placeholder: "MM-DD-YYYY",
-                        },
-                        ...register("start_date"),
-                      }}
-                      value={dayjs(value)}
-                      onChange={(event) => {
-                        onChange(event);
-                      }}
-                      defaultValue={dayjs(
-                        taskEvent?.start_date ? taskEvent?.start_date : ""
-                      )}
-                      sx={{ display: "block" }}
-                    />
-                  </LocalizationProvider>
-                )}
+                datePickerProps={{
+                  onDateChange: (event: any, defaultOnChange: any) => {
+                    defaultOnChange(event);
+                  },
+                }}
+                datePickerSlotProps={{
+                  inputRef: startDateRef,
+                }}
               />
             </Grid>
             <Grid item xs={4}>
               <ETFormLabel>Number of Days</ETFormLabel>
-              <TextField
-                fullWidth
+              <ControlledTextField
+                name="number_of_days"
                 defaultValue={taskEvent?.number_of_days}
+                fullWidth
                 InputProps={{
                   inputProps: {
                     min: 0,
@@ -277,49 +253,35 @@ const TaskForm = ({
                 }}
                 inputRef={numberOfDaysRef}
                 type="number"
-                {...register("number_of_days")}
                 onChange={daysOnChangeHandler}
               />
             </Grid>
             <Grid item xs={4}>
               <ETFormLabel>End Date</ETFormLabel>
-              <Controller
-                name="start_date"
-                control={control}
-                render={({
-                  field: { onChange, value },
-                  fieldState: { error },
-                }) => (
-                  <LocalizationProvider dateAdapter={AdapterDayjs}>
-                    <DatePicker
-                      format={DATE_FORMAT}
-                      slotProps={{
-                        textField: {
-                          id: "start_date",
-                          fullWidth: true,
-                          inputRef: endDateRef,
-                          error: error ? true : false,
-                          helperText: error?.message,
-                          placeholder: "MM-DD-YYYY",
-                        },
-                      }}
-                      value={dayjs(
-                        dateUtils
-                          .add(
-                            taskEvent?.start_date || "",
-                            taskEvent?.number_of_days || 0,
-                            "days"
-                          )
-                          .toString()
-                      )}
-                      onChange={(event: any) => {
-                        const d = event ? event["$d"] : null;
-                        endDateChangeHandler(d);
-                      }}
-                      sx={{ display: "block" }}
-                    />
-                  </LocalizationProvider>
+              <TrackDatePicker
+                slotProps={{
+                  textField: {
+                    id: "end_date",
+                    fullWidth: true,
+                    inputRef: endDateRef,
+                    placeholder: "MM-DD-YYYY",
+                    error: !!errors["start_date"],
+                    helperText: errors["start_date"]?.message,
+                  },
+                }}
+                value={dayjs(
+                  dateUtils
+                    .add(
+                      taskEvent?.start_date || "",
+                      taskEvent?.number_of_days || 0,
+                      "days"
+                    )
+                    .toString()
                 )}
+                onChange={(event: any) => {
+                  const d = event ? event["$d"] : null;
+                  endDateChangeHandler(d);
+                }}
               />
             </Grid>
             <Grid item xs={5}>


### PR DESCRIPTION
https://app.zenhub.com/workspaces/epictrack-63891ea941d309001fa292cf/issues/gh/bcgov/epic.track/1502

Details:
- Pass on all instances where DatePicker was used directly and replace it with TrackDatePicker or ControlledDatePicker
- in same files replace raw use of TextField with ControlledTextfield