### PR TITLE
Fixed-ProponentName-History-Padding&Disabled

### DIFF
--- a/epictrack-web/src/components/proponent/ProponentForm.tsx
+++ b/epictrack-web/src/components/proponent/ProponentForm.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { TextField, Grid, Box, IconButton } from "@mui/material";
+import { TextField, Grid, Box } from "@mui/material";
 import { FormProvider, useForm } from "react-hook-form";
 import * as yup from "yup";
 import { yupResolver } from "@hookform/resolvers/yup";
@@ -11,15 +11,8 @@ import ControlledSelectV2 from "../shared/controlledInputComponents/ControlledSe
 import { MasterContext } from "../shared/MasterContext";
 import proponentService from "../../services/proponentService/proponentService";
 import ControlledSwitch from "../shared/controlledInputComponents/ControlledSwitch";
-import { When, If, Then, Else } from "react-if";
-import {
-  SpecialFieldEntityEnum,
-  SPECIAL_FIELDS,
-} from "../../constants/application-constant";
 import Icons from "../icons";
 import { IconProps } from "../icons/type";
-import { Palette } from "../../styles/theme";
-import { SpecialFieldGrid } from "../shared/specialField";
 import { ProponentNameSpecialField } from "./ProponentNameSpecialField";
 
 const schema = yup.object().shape({
@@ -49,7 +42,6 @@ export default function ProponentForm({ ...props }) {
   const [staffs, setStaffs] = React.useState<Staff[]>([]);
   const [disabled, setDisabled] = React.useState<boolean>();
   const ctx = React.useContext(MasterContext);
-  const [specialField, setSpecialField] = React.useState<string>("");
   const [isNameFieldLocked, setIsNameFieldLocked] =
     React.useState<boolean>(false);
 
@@ -128,7 +120,7 @@ export default function ProponentForm({ ...props }) {
           >
             <TextField
               variant="outlined"
-              disabled={disabled}
+              disabled={isNameFieldLocked}
               placeholder="Proponent Name"
               fullWidth
               error={!!errors?.name?.message}
@@ -138,9 +130,9 @@ export default function ProponentForm({ ...props }) {
           </ProponentNameSpecialField>
           <Grid item xs={6}>
             <ETFormLabel>Relationship Holder</ETFormLabel>
-            <Box sx={{ paddingTop: Boolean(specialField) ? "15px" : "11px" }}>
+            <Box>
               <ControlledSelectV2
-                disabled={Boolean(specialField)}
+                disabled={Boolean(isNameFieldLocked)}
                 placeholder="Select"
                 defaultValue={(ctx.item as Proponent)?.relationship_holder_id}
                 options={staffs || []}
@@ -152,7 +144,7 @@ export default function ProponentForm({ ...props }) {
           </Grid>
           <Grid item xs={6} sx={{ paddingTop: "30px !important" }}>
             <ControlledSwitch
-              disabled={Boolean(specialField)}
+              disabled={Boolean(isNameFieldLocked)}
               sx={{ paddingLeft: "0px", marginRight: "10px" }}
               name="is_active"
             />


### PR DESCRIPTION
#999 
- Corrected the disabled condition when the history field is open for editing
- Padding Top of the RelationshipHolder field is adjusted