### PR TITLE
Remove 'required' tag from Work Description label

### DIFF
--- a/epictrack-web/src/components/work/WorkForm/index.tsx
+++ b/epictrack-web/src/components/work/WorkForm/index.tsx
@@ -326,7 +326,7 @@ export default function WorkForm({ ...props }) {
           />
         </Grid>
         <Grid item xs={12}>
-          <ETFormLabel required>Work Description</ETFormLabel>
+          <ETFormLabel>Work Description</ETFormLabel>
           <ControlledTextField
             name="report_description"
             placeholder="Description will be shown on all reports"


### PR DESCRIPTION
#1585 

-Looked at the backend and saw that report_description is not required 

-Do we remove the required label or do we change the backend to make report_description required

![image](https://github.com/bcgov/EPIC.track/assets/103138766/5ad4422c-bda3-49e2-a56a-deef2a7f9afe)

