### PR TITLE
Make Work description mandatory to match backend

### DIFF
--- a/epictrack-web/src/components/work/WorkForm/index.tsx
+++ b/epictrack-web/src/components/work/WorkForm/index.tsx
@@ -326,7 +326,7 @@ export default function WorkForm({ ...props }) {
           />
         </Grid>
         <Grid item xs={12}>
-          <ETFormLabel required>Work Description</ETFormLabel>
+          <ETFormLabel>Work Description</ETFormLabel>
           <ControlledTextField
             name="report_description"
             placeholder="Description will be shown on all reports"

--- a/epictrack-web/src/components/work/WorkForm/index.tsx
+++ b/epictrack-web/src/components/work/WorkForm/index.tsx
@@ -35,6 +35,7 @@ const schema = yup.object<Work>().shape({
   federal_involvement_id: yup
     .number()
     .required("Federal Involvement is required"),
+  report_description: yup.string().required("Description is required"),
   title: yup
     .string()
     .required("Title is required")
@@ -326,7 +327,7 @@ export default function WorkForm({ ...props }) {
           />
         </Grid>
         <Grid item xs={12}>
-          <ETFormLabel>Work Description</ETFormLabel>
+          <ETFormLabel required>Work Description</ETFormLabel>
           <ControlledTextField
             name="report_description"
             placeholder="Description will be shown on all reports"

--- a/epictrack-web/src/components/work/WorkForm/index.tsx
+++ b/epictrack-web/src/components/work/WorkForm/index.tsx
@@ -35,7 +35,7 @@ const schema = yup.object<Work>().shape({
   federal_involvement_id: yup
     .number()
     .required("Federal Involvement is required"),
-  report_description: yup.string().required("Work Description is required"),
+  report_description: yup.string().required("Work description is required"),
   title: yup
     .string()
     .required("Title is required")

--- a/epictrack-web/src/components/work/WorkForm/index.tsx
+++ b/epictrack-web/src/components/work/WorkForm/index.tsx
@@ -35,7 +35,7 @@ const schema = yup.object<Work>().shape({
   federal_involvement_id: yup
     .number()
     .required("Federal Involvement is required"),
-  report_description: yup.string().required("Description is required"),
+  report_description: yup.string().required("Work Description is required"),
   title: yup
     .string()
     .required("Title is required")


### PR DESCRIPTION
#1585 

In the back end work description is mandatory but it is not mandatory in the front end. Updated Create Work form to match.

![image](https://github.com/bcgov/EPIC.track/assets/103138766/8413baed-c848-4ca7-9ac7-a2165cc7cb4d)
