### PR TITLE
Remove the Environment Banner from production environment

### DIFF
--- a/epictrack-web/src/components/layout/Header/EnvironmentBanner.tsx
+++ b/epictrack-web/src/components/layout/Header/EnvironmentBanner.tsx
@@ -9,8 +9,7 @@ import { AppConfig } from "../../../config";
 const EnvironmentBanner = () => {
   const dispatch = useAppDispatch();
   const env = AppConfig.environment;
-  const isTestEnvironment =
-    env === "dev" || env === "test" || env === "demo" || env === "localhost";
+  const isTestEnvironment = ["dev", "test", "demo", "localhost"].includes(env);
 
   React.useEffect(() => {
     dispatch(envBanner(isTestEnvironment));
@@ -44,7 +43,7 @@ const EnvironmentBanner = () => {
       textAlign="center"
     >
       <Box component="img" src={InfoIcon} alt="EPIC.track" />
-      <ETSubhead>You are using a TEST environment</ETSubhead>
+      <ETSubhead>You are using a {env.toUpperCase()} environment</ETSubhead>
     </Box>
   );
 };

--- a/epictrack-web/src/components/layout/Header/EnvironmentBanner.tsx
+++ b/epictrack-web/src/components/layout/Header/EnvironmentBanner.tsx
@@ -5,18 +5,17 @@ import { useAppDispatch } from "../../../hooks";
 import { envBanner } from "../../../styles/uiStateSlice";
 import InfoIcon from "../../../assets/images/infoIcon.svg";
 import { ETSubhead } from "../../shared";
-
+import { AppConfig } from "../../../config";
 const EnvironmentBanner = () => {
   const dispatch = useAppDispatch();
-  const host = window.location.hostname;
+  const env = AppConfig.environment;
   const isTestEnvironment =
-    host.indexOf("dev") !== -1 ||
-    host.indexOf("test") !== -1 ||
-    host.indexOf("demo") !== -1 ||
-    host.indexOf("localhost") !== -1;
+    env === "dev" || env === "test" || env === "demo" || env === "localhost";
+
   React.useEffect(() => {
     dispatch(envBanner(isTestEnvironment));
   }, []);
+
   if (!isTestEnvironment) {
     return (
       <Box
@@ -28,6 +27,7 @@ const EnvironmentBanner = () => {
       ></Box>
     );
   }
+
   return (
     <Box
       sx={{

--- a/epictrack-web/src/config.tsx
+++ b/epictrack-web/src/config.tsx
@@ -24,7 +24,7 @@ const KC_REALM =
   window._env_?.REACT_APP_KEYCLOAK_REALM ||
   process.env.REACT_APP_KEYCLOAK_REALM;
 const APP_ENVIRONMENT =
-  window._env_?.REACT_APP_ENV || process.env.REACT_APP_ENV;
+  window._env_?.REACT_APP_ENV || process.env.REACT_APP_ENV || "";
 
 export const AppConfig = {
   apiUrl: `${API_URL}/api/v1/`,

--- a/epictrack-web/src/config.tsx
+++ b/epictrack-web/src/config.tsx
@@ -7,6 +7,7 @@ declare global {
       REACT_APP_KEYCLOAK_URL: string;
       REACT_APP_KEYCLOAK_CLIENT: string;
       REACT_APP_KEYCLOAK_REALM: string;
+      REACT_APP_ENV: string;
     };
   }
 }
@@ -22,9 +23,12 @@ const KC_CLIENT =
 const KC_REALM =
   window._env_?.REACT_APP_KEYCLOAK_REALM ||
   process.env.REACT_APP_KEYCLOAK_REALM;
+const APP_ENVIRONMENT =
+  window._env_?.REACT_APP_ENV || process.env.REACT_APP_ENV;
 
 export const AppConfig = {
   apiUrl: `${API_URL}/api/v1/`,
+  environment: APP_ENVIRONMENT,
   keycloak: {
     url: KC_URL || "",
     clientId: KC_CLIENT || "",


### PR DESCRIPTION
#1637 

Remove the banner from the production environment 

-refactor to use env variables instead of window.location 