### PR TITLE
Restrict workplan tab actions

### DIFF
--- a/epictrack-api/src/api/resources/event.py
+++ b/epictrack-api/src/api/resources/event.py
@@ -24,7 +24,6 @@ from api.utils import auth, profiletime
 from api.utils.util import cors_preflight
 from api.utils.datetime_helper import get_start_of_day
 
-
 API = Namespace("milestones", description="Milestones")
 
 

--- a/epictrack-api/src/api/resources/task.py
+++ b/epictrack-api/src/api/resources/task.py
@@ -71,7 +71,9 @@ class Events(Resource):
     def delete():
         """Delete tasks."""
         request_json = req.TasksBulkDeleteQueryParamSchema().load(request.args)
-        result = TaskService.bulk_delete_tasks(request_json["task_ids"])
+        task_ids = request_json.get("task_ids")
+        work_id = request_json.get("work_id")
+        result = TaskService.bulk_delete_tasks(task_ids, work_id)
         return result, HTTPStatus.OK
 
 

--- a/epictrack-api/src/api/schemas/request/task_request.py
+++ b/epictrack-api/src/api/schemas/request/task_request.py
@@ -246,3 +246,8 @@ class TasksBulkDeleteQueryParamSchema(RequestQueryParameterSchema):
     """Tasks bulk delete query parameter"""
 
     task_ids = IntegerList(metadata={"description": "comma separated task ids"})
+    work_id = fields.Int(
+        metadata={"description": "Work id of the task"},
+        validate=validate.Range(min=1),
+        required=True,
+    )

--- a/epictrack-api/src/api/services/authorisation.py
+++ b/epictrack-api/src/api/services/authorisation.py
@@ -48,4 +48,4 @@ def _has_team_membership(kwargs, team_permitted_roles) -> bool:
 
     membership_ids = {membership.value for membership in Membership}
 
-    return any(role.id in membership_ids for role in work_roles)
+    return any(work_role.role_id in membership_ids for work_role in work_roles)

--- a/epictrack-api/src/api/services/event.py
+++ b/epictrack-api/src/api/services/event.py
@@ -15,6 +15,7 @@
 import copy
 import functools
 from datetime import datetime, timedelta
+from typing import List
 
 from sqlalchemy import and_, extract, func, or_
 

--- a/epictrack-api/src/api/services/event.py
+++ b/epictrack-api/src/api/services/event.py
@@ -15,7 +15,6 @@
 import copy
 import functools
 from datetime import datetime, timedelta
-from typing import List
 
 from sqlalchemy import and_, extract, func, or_
 
@@ -42,8 +41,10 @@ from api.models.project import Project
 from api.models.work_type import WorkType
 from api.services.outcome_configuration import OutcomeConfigurationService
 from api.utils import util
+from . import authorisation
 
 from .event_configuration import EventConfigurationService
+from ..utils.roles import Membership, Role as KeycloakRole
 
 
 # pylint:disable=not-callable
@@ -58,6 +59,13 @@ class EventService:
     ) -> Event:
         """Create milestone event"""
         current_work_phase = WorkPhase.find_by_id(work_phase_id)
+
+        one_of_roles = (
+            Membership.TEAM_MEMBER.name,
+            KeycloakRole.CREATE.value,
+        )
+        authorisation.check_auth(one_of_roles=one_of_roles, work_id=current_work_phase.work_id)
+
         all_work_events = cls.find_events(
             current_work_phase.work_id, None, PRIMARY_CATEGORIES, True
         )
@@ -82,6 +90,13 @@ class EventService:
         current_work_phase = WorkPhase.find_by_id(
             event.event_configuration.work_phase_id
         )
+
+        one_of_roles = (
+            Membership.TEAM_MEMBER.name,
+            KeycloakRole.EDIT.value,
+        )
+        authorisation.check_auth(one_of_roles=one_of_roles, work_id=current_work_phase.work_id)
+
         all_work_events = cls.find_events(
             current_work_phase.work_id, None, PRIMARY_CATEGORIES, True
         )
@@ -906,6 +921,13 @@ class EventService:
         event = Event.find_by_id(event_id)
         if not event:
             raise ResourceNotFoundError("No event found with given id")
+
+        one_of_roles = (
+            Membership.TEAM_MEMBER.name,
+            KeycloakRole.CREATE.value,
+        )
+        authorisation.check_auth(one_of_roles=one_of_roles, work_id=event.work_id)
+
         if event.actual_date:
             raise UnprocessableEntityError("Locked events cannot be deleted")
         db.session.query(Event).filter(

--- a/epictrack-web/src/components/shared/restricted/index.tsx
+++ b/epictrack-web/src/components/shared/restricted/index.tsx
@@ -31,7 +31,6 @@ export function Restricted({
   allowed = [],
 }: RestrictedProps): React.ReactElement<any, any> {
   const { roles } = useAppSelector((state) => state.user.userDetail);
-
   const permissionGranted = exception || hasPermission({ roles, allowed });
 
   if (!permissionGranted && !errorProps && RenderError) return <RenderError />;

--- a/epictrack-web/src/components/workPlan/event/EventList.tsx
+++ b/epictrack-web/src/components/workPlan/event/EventList.tsx
@@ -50,25 +50,19 @@ import EventForm from "./EventForm";
 import { EventContext } from "./EventContext";
 import { When } from "react-if";
 import WarningBox from "../../shared/warningBox";
-import { useAppDispatch } from "../../../hooks";
+import { useAppDispatch, useAppSelector } from "../../../hooks";
 import { setLoadingState } from "../../../services/loadingService";
 import { getErrorMessage } from "../../../utils/axiosUtils";
-import { COMMON_ERROR_MESSAGE } from "../../../constants/application-constant";
+import {
+  COMMON_ERROR_MESSAGE,
+  ROLES,
+} from "../../../constants/application-constant";
+import { Restricted } from "components/shared/restricted";
 
 const ImportFileIcon: React.FC<IconProps> = Icons["ImportFileIcon"];
 const DownloadIcon: React.FC<IconProps> = Icons["DownloadIcon"];
 const DeleteIcon: React.FC<IconProps> = Icons["DeleteIcon"];
 
-const classes = {
-  textEllipsis: {
-    textOverflow: "ellipsis",
-    whiteSpace: "nowrap",
-    overflow: "hidden",
-  },
-  deleteIcon: {
-    fill: "currentcolor",
-  },
-};
 const IButton = styled(IconButton)({
   "& .icon": {
     fill: Palette.primary.accent.main,
@@ -99,7 +93,14 @@ const EventList = () => {
   const [selectedTemplateId, setSelectedTemplateId] = React.useState<number>();
   const [showTemplateForm, setShowTemplateForm] =
     React.useState<boolean>(false);
+
   const ctx = useContext(WorkplanContext);
+  const { email } = useAppSelector((state) => state.user.userDetail);
+  const userIsTeamMember = useMemo(
+    () => ctx.team.some((member) => member.staff.email === email),
+    [ctx.team, email]
+  );
+
   const { handleHighlightRows } = useContext(EventContext);
   const [rowSelection, setRowSelection] = React.useState<MRT_RowSelectionState>(
     {}
@@ -728,14 +729,26 @@ const EventList = () => {
       </Grid>
       <Grid container item columnSpacing={2}>
         <Grid item xs="auto">
-          <Button variant="contained" onClick={() => setShowTaskForm(true)}>
-            Add Task
-          </Button>
+          <Restricted
+            allowed={[ROLES.CREATE]}
+            errorProps={{ disabled: true }}
+            exception={userIsTeamMember}
+          >
+            <Button variant="contained" onClick={() => setShowTaskForm(true)}>
+              Add Task
+            </Button>
+          </Restricted>
         </Grid>
         <Grid item xs="auto">
-          <Button variant="outlined" onClick={onAddMilestone}>
-            Add Milestone
-          </Button>
+          <Restricted
+            allowed={[ROLES.CREATE]}
+            errorProps={{ disabled: true }}
+            exception={userIsTeamMember}
+          >
+            <Button variant="outlined" onClick={onAddMilestone}>
+              Add Milestone
+            </Button>
+          </Restricted>
         </Grid>
         <Grid
           item

--- a/epictrack-web/src/components/workPlan/event/EventList.tsx
+++ b/epictrack-web/src/components/workPlan/event/EventList.tsx
@@ -543,7 +543,11 @@ const EventList = () => {
       assignee_ids = assignee_ids.filter(
         (assignee_id: string) => assignee_id !== "<SELECT_ALL>"
       );
-      const data = { task_ids: Object.keys(rowSelection), assignee_ids };
+      const data = {
+        task_ids: Object.keys(rowSelection),
+        assignee_ids,
+        work_id: ctx.work?.id,
+      };
       const result = await taskEventService.patchTasks(data);
       try {
         if (result.status === 200) {
@@ -576,6 +580,7 @@ const EventList = () => {
       const data = {
         task_ids: Object.keys(rowSelection),
         responsibility_ids,
+        work_id: ctx.work?.id,
       };
       const result = await taskEventService.patchTasks(data);
       try {
@@ -606,6 +611,7 @@ const EventList = () => {
       const data = {
         task_ids: Object.keys(rowSelection),
         status,
+        work_id: ctx.work?.id,
       };
       const result = await taskEventService.patchTasks(data);
       try {
@@ -634,6 +640,7 @@ const EventList = () => {
   const deleteTasks = async () => {
     const data = {
       task_ids: Object.keys(rowSelection).join(","),
+      work_id: ctx.work?.id,
     };
     const response = await taskEventService.deleteTasks(data);
     try {


### PR DESCRIPTION
https://app.zenhub.com/workspaces/epictrack-63891ea941d309001fa292cf/issues/gh/bcgov/epic.track/1579

Details:
- Use Restrict component to wrap buttons
- Add auth_check for all the services in the backend
- Add work_id in the request body to some bulk operations to be able to use it in auth_check