### PR TITLE
Update search filter in backend to be ilike instead of exact match

### DIFF
--- a/epictrack-api/src/api/models/work.py
+++ b/epictrack-api/src/api/models/work.py
@@ -165,7 +165,7 @@ class Work(BaseModelVersioned):
     @classmethod
     def _filter_by_search_text(cls, query, search_text):
         if search_text:
-            subquery = exists().where(and_(Work.project_id == Project.id, Project.name == search_text))
+            subquery = exists().where(and_(Work.project_id == Project.id, Project.name.ilike(f'%{search_text}%')))
             query = query.filter(subquery)
         return query
 


### PR DESCRIPTION
https://app.zenhub.com/workspaces/epictrack-63891ea941d309001fa292cf/issues/gh/bcgov/epic.track/1583

Details:
- Change == to ilike for search text filter