### PR TITLE
Get current milestone from previous  work phase if current is empty

### DIFF
--- a/epictrack-web/src/components/workPlan/about/aboutDetails/WorkDetails.tsx
+++ b/epictrack-web/src/components/workPlan/about/aboutDetails/WorkDetails.tsx
@@ -12,6 +12,8 @@ const WorkDetails = () => {
   const currentWorkPhaseIndex = workPhases?.findIndex(
     (phase) => phase.work_phase.id === work?.current_work_phase_id
   );
+  const previousWorkPhase =
+    currentWorkPhaseIndex > 0 ? workPhases?.[currentWorkPhaseIndex - 1] : null;
   const currentWorkPhase = workPhases?.[currentWorkPhaseIndex];
   const nextWorkPhase =
     currentWorkPhaseIndex + 1 < workPhases.length
@@ -59,7 +61,9 @@ const WorkDetails = () => {
 
         <Grid item xs={6}>
           <ETParagraph color={Palette.neutral.dark}>
-            {currentWorkPhase?.current_milestone ?? "-"}
+            {currentWorkPhase?.current_milestone ??
+              previousWorkPhase?.current_milestone ??
+              "-"}
           </ETParagraph>
         </Grid>
 


### PR DESCRIPTION
https://app.zenhub.com/workspaces/epictrack-63891ea941d309001fa292cf/issues/gh/bcgov/epic.track/1512

Details:
- if current work phase has 0 completed, in about page display current milestone of previous completed work phase
- All UI no backend logic change