### PR TITLE
Sort staff in staff page by sort order

### DIFF
--- a/epictrack-web/src/components/staff/StaffList.tsx
+++ b/epictrack-web/src/components/staff/StaffList.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { MRT_ColumnDef } from "material-react-table";
-import { Edit as EditIcon, Delete as DeleteIcon } from "@mui/icons-material";
-import { Box, Button, Grid, IconButton } from "@mui/material";
+import { Box, Button, Grid } from "@mui/material";
 import StaffForm from "./StaffForm";
 import { Staff } from "../../models/staff";
 import MasterTrackTable from "../shared/MasterTrackTable";
@@ -51,7 +50,11 @@ const StaffList = () => {
   React.useEffect(() => {
     if (staff) {
       const positions = staff
-        .map((p) => p.position?.name)
+        .map((staff) => staff.position)
+        .sort(
+          (positionA, positionB) => positionA.sort_order - positionB.sort_order
+        )
+        .map((position) => position.name)
         .filter((ele, index, arr) => arr.findIndex((t) => t === ele) === index);
       setPositions(positions);
     }

--- a/epictrack-web/src/models/staff.ts
+++ b/epictrack-web/src/models/staff.ts
@@ -11,7 +11,7 @@ export interface Staff extends MasterBase {
   first_name: string;
   last_name: string;
   full_name: string;
-  position: ListType;
+  position: ListType & { sort_order: number };
 }
 
 export interface StaffRole extends Staff {


### PR DESCRIPTION
https://app.zenhub.com/workspaces/epictrack-63891ea941d309001fa292cf/issues/gh/bcgov/epic.track/1588

Details:
- add sortingFn to sort by position.sort_order
- Update initial sort to sort by sort_order then full_name