### PR TITLE
Abbreviation input was taking user input even though user doesn't have permission

### DIFF
--- a/epictrack-web/src/components/project/ProjectForm/index.tsx
+++ b/epictrack-web/src/components/project/ProjectForm/index.tsx
@@ -458,7 +458,6 @@ export default function ProjectForm({ ...props }) {
             <Restricted
               allowed={[ROLES.EXTENDED_EDIT]}
               errorProps={{ disabled: true }}
-              exception={!abbreviation}
             >
               <ControlledTextField
                 name={"abbreviation"}

--- a/epictrack-web/src/components/project/ProjectForm/index.tsx
+++ b/epictrack-web/src/components/project/ProjectForm/index.tsx
@@ -456,8 +456,9 @@ export default function ProjectForm({ ...props }) {
           <Grid item xs={6}>
             <ETFormLabel>Abbreviation</ETFormLabel>
             <Restricted
-              allowed={[ROLES.EXTENDED_EDIT]}
+              allowed={[ROLES.EDIT]}
               errorProps={{ disabled: true }}
+              exception={!abbreviation}
             >
               <ControlledTextField
                 name={"abbreviation"}


### PR DESCRIPTION
#1732 
User without "extended_edit" permission tries to change abbreviation field in project form can type first alphabet then the textbox gets disabled.
This was due to the fact that "exception" property was set in the <Restricted component which was causing a false positive condition triggered inside on the initial load