### PR TITLE
team info edit button removal, migration fix, work title display getting undefined at times

### DIFF
--- a/epictrack-web/src/components/work/WorkForm/index.tsx
+++ b/epictrack-web/src/components/work/WorkForm/index.tsx
@@ -100,8 +100,8 @@ export default function WorkForm({ ...props }) {
     watch,
   } = methods;
 
-  const work_type_id = watch("work_type_id");
-  const project_id = watch("project_id");
+  const workTypeId = watch("work_type_id");
+  const projectId = watch("project_id");
 
   const work = ctx?.item as Work;
 
@@ -206,16 +206,14 @@ export default function WorkForm({ ...props }) {
   const titleSeparator = " - ";
   const getTitlePrefix = () => {
     let prefix = "";
-    if (project_id) {
+    if (projectId) {
       const project = projects.find(
-        (project) => project.id === Number(project_id)
+        (project) => project.id === Number(projectId)
       );
       prefix += `${project?.name}${titleSeparator}`;
     }
-    if (work_type_id) {
-      const workType = workTypes.find(
-        (type) => type.id === Number(work_type_id)
-      );
+    if (workTypeId) {
+      const workType = workTypes.find((type) => type.id === Number(workTypeId));
       prefix += `${workType?.name}${titleSeparator}`;
     }
     return prefix;
@@ -224,7 +222,7 @@ export default function WorkForm({ ...props }) {
   useEffect(() => {
     const prefix = getTitlePrefix();
     setTitlePrefix(prefix);
-  }, [work_type_id, project_id]);
+  }, [workTypeId, projectId, projects, workTypes]);
 
   React.useEffect(() => {
     setValue("title", `${titlePrefix}${simple_title}`);

--- a/epictrack-web/src/components/workPlan/team/TeamInfo.tsx
+++ b/epictrack-web/src/components/workPlan/team/TeamInfo.tsx
@@ -47,7 +47,7 @@ const TeamInfoBox = (props: TeamInfoBoxProps) => {
               {props.value}
             </ETSubhead>
           </Grid>
-          <Grid
+          {/* <Grid
             item
             xs={2}
             sx={{
@@ -56,10 +56,10 @@ const TeamInfoBox = (props: TeamInfoBoxProps) => {
               justifyContent: "space-evenly",
               cursor: "pointer",
             }}
-          >
-            {/* Commenting this out as this has to bring back when we finalize what to do with this feature */}
-            {/* <EditIcon fill={Palette.primary.accent.main} /> */}
-            {/* <ETCaption2
+          > */}
+          {/* Commenting this out as this has to bring back when we finalize what to do with this feature */}
+          {/* <EditIcon fill={Palette.primary.accent.main} /> */}
+          {/* <ETCaption2
               bold
               sx={{
                 color: Palette.primary.accent.main,
@@ -67,7 +67,7 @@ const TeamInfoBox = (props: TeamInfoBoxProps) => {
             >
               Edit
             </ETCaption2> */}
-          </Grid>
+          {/* </Grid> */}
         </Grid>
       </Grid>
     </Grid>


### PR DESCRIPTION
#1698 
- Migration fixed. Using query instead of Model class
- Commented the whole edit button box in team tab
- Work title display logic gets undefind at times(if the projects, worktypes not loaded completely)