### PR TITLE
Toggle assigneeToggle off if no workplans on first load

### DIFF
--- a/epictrack-web/src/components/myWorkplans/Filters/AssigneeToggle.tsx
+++ b/epictrack-web/src/components/myWorkplans/Filters/AssigneeToggle.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { Stack } from "@mui/material";
 import { useAppSelector } from "../../../hooks";
 import { ETCaption2 } from "../../shared";
@@ -8,7 +8,9 @@ import { MyWorkplansContext } from "../MyWorkPlanContext";
 
 export const AssigneeToggle = () => {
   const user = useAppSelector((state) => state.user.userDetail);
-  const { searchOptions, setSearchOptions } = useContext(MyWorkplansContext);
+  const { searchOptions, setSearchOptions, loadingWorkplans, totalWorkplans } =
+    useContext(MyWorkplansContext);
+  const [haveInitializedtoggle, setHaveInitializedToggle] = useState(false);
 
   const [isUsersWorkPlans, setIsUsersWorkPlans] = useState(
     Boolean(searchOptions.staff_id)
@@ -21,6 +23,15 @@ export const AssigneeToggle = () => {
       staff_id: checked ? user.staffId : null,
     }));
   };
+
+  useEffect(() => {
+    if (!haveInitializedtoggle && !loadingWorkplans) {
+      setHaveInitializedToggle(true);
+      if (totalWorkplans === 0) {
+        handleToggleChange(false);
+      }
+    }
+  }, [loadingWorkplans]);
 
   return (
     <Stack direction="row" spacing={1} alignItems={"center"}>

--- a/epictrack-web/src/components/myWorkplans/MyWorkPlanContext.tsx
+++ b/epictrack-web/src/components/myWorkplans/MyWorkPlanContext.tsx
@@ -3,6 +3,8 @@ import { WorkPlan } from "../../models/workplan";
 import workplanService from "../../services/workplanService";
 import { WORK_STATE } from "../shared/constants";
 import { useAppSelector } from "../../hooks";
+import { showNotification } from "components/shared/notificationProvider";
+import { COMMON_ERROR_MESSAGE } from "constants/application-constant";
 
 interface MyWorkplanContextProps {
   workplans: WorkPlan[];
@@ -92,7 +94,9 @@ export const MyWorkplansProvider = ({
       setTotalWorkplans(result.data.total);
       setLoadingWorkplans(false);
     } catch (error) {
-      console.log(error);
+      showNotification(COMMON_ERROR_MESSAGE, {
+        type: "error",
+      });
     }
   };
 

--- a/epictrack-web/src/components/workPlan/WorkPlanContainer.tsx
+++ b/epictrack-web/src/components/workPlan/WorkPlanContainer.tsx
@@ -15,7 +15,6 @@ import Icons from "../icons";
 import { IconProps } from "../icons/type";
 import Issues from "./issues";
 import WorkState from "./WorkState";
-import ComingSoon from "../../routes/ComingSoon";
 import { isStatusOutOfDate } from "./status/shared";
 import About from "./about";
 


### PR DESCRIPTION
https://app.zenhub.com/workspaces/epictrack-63891ea941d309001fa292cf/issues/gh/bcgov/epic.track/1750

Details:
The ask is if a user is unassigned to anything the my workplan's toggle should be off to not show an empty page. To do that exactly we need to know beforehand whether the user is a member of anything or not, and to decide whether to fetch that and store it in redux is beyond the scope of this task.

So what I did instead:
- Given that toggle is on initially, if loading workplans returned 0 result, toggle it off and load again