### PR TITLE
pre wrap status description in referral schedule as well

### DIFF
--- a/epictrack-web/src/components/workPlan/issues/ReportsPreview/ReferralSchedule.tsx
+++ b/epictrack-web/src/components/workPlan/issues/ReportsPreview/ReferralSchedule.tsx
@@ -76,7 +76,9 @@ export const ReferralSchedule = () => {
                 .format("MMM.DD YYYY")
                 .toUpperCase()})`}
             </ETCaption2>
-            <ETPreviewText sx={{ whiteSpace: "pre-wrap" }}>{currentStatus?.description}</ETPreviewText>
+            <ETPreviewText sx={{ whiteSpace: "pre-wrap" }}>
+              {currentStatus?.description}
+            </ETPreviewText>
           </Grid>
         </When>
 

--- a/epictrack-web/src/components/workPlan/issues/ReportsPreview/ReferralSchedule.tsx
+++ b/epictrack-web/src/components/workPlan/issues/ReportsPreview/ReferralSchedule.tsx
@@ -76,7 +76,7 @@ export const ReferralSchedule = () => {
                 .format("MMM.DD YYYY")
                 .toUpperCase()})`}
             </ETCaption2>
-            <ETPreviewText>{currentStatus?.description}</ETPreviewText>
+            <ETPreviewText sx={{ whiteSpace: "pre-wrap" }}>{currentStatus?.description}</ETPreviewText>
           </Grid>
         </When>
 


### PR DESCRIPTION
https://app.zenhub.com/workspaces/epictrack-63891ea941d309001fa292cf/issues/gh/bcgov/epic.track/1752

Details:
- in issue tab, status description is pre wrapped in 30-60-90. I pre-wrapped it as well in Referral Schedule to have consistent formatting