### PR TITLE
Workplan page r.state is null bug fix

### DIFF
--- a/epictrack-web/src/components/workPlan/WorkPlanContainer.tsx
+++ b/epictrack-web/src/components/workPlan/WorkPlanContainer.tsx
@@ -27,10 +27,11 @@ const tabPanel: SxProps = {
 };
 const WorkPlanContainer = () => {
   const location = useLocation();
-  const { tabIndex } = location.state;
-  const [selectedTabIndex, setSelectedTabIndex] = React.useState(
-    tabIndex ?? WORKPLAN_TAB_INDEX.WORKPLAN
-  );
+
+  const tabIndex = location.state?.tabIndex ?? WORKPLAN_TAB_INDEX.WORKPLAN;
+
+  const [selectedTabIndex, setSelectedTabIndex] = React.useState(tabIndex);
+
   const ctx = useContext(WorkplanContext);
 
   const activeStaff = ctx.team.filter(


### PR DESCRIPTION
-When you would load a workplan in a new tab or from a url it would crash.

-This fix handles the location.state not existing 