### PR TITLE
Use redux RTK to add caching to insights page

### DIFF
--- a/epictrack-web/src/components/insights/Work/ButtonBar.tsx
+++ b/epictrack-web/src/components/insights/Work/ButtonBar.tsx
@@ -15,16 +15,16 @@ const ButtonBar = () => {
       width="100%"
     >
       <TabButton
-        active={activeTab === WORK_INSIGHTS_TAB.Staff}
-        onClick={() => setActiveTab(WORK_INSIGHTS_TAB.Staff)}
-      >
-        Staff
-      </TabButton>
-      <TabButton
         active={activeTab === WORK_INSIGHTS_TAB.General}
         onClick={() => setActiveTab(WORK_INSIGHTS_TAB.General)}
       >
         General
+      </TabButton>
+      <TabButton
+        active={activeTab === WORK_INSIGHTS_TAB.Staff}
+        onClick={() => setActiveTab(WORK_INSIGHTS_TAB.Staff)}
+      >
+        Staff
       </TabButton>
       <TabButton
         active={activeTab === WORK_INSIGHTS_TAB.Partners}

--- a/epictrack-web/src/components/insights/Work/Tabs/General/charts/AssessmentByPhase.tsx
+++ b/epictrack-web/src/components/insights/Work/Tabs/General/charts/AssessmentByPhase.tsx
@@ -51,7 +51,7 @@ const AssessmentByPhaseChart = () => {
           </ETCaption3>
         </Grid>
         <Grid item xs={12} container justifyContent={"center"}>
-          <PieChart width={500} height={300}>
+          <PieChart width={600} height={300}>
             <Pie
               data={chartData}
               cx="50%"

--- a/epictrack-web/src/components/insights/Work/Tabs/General/charts/AssessmentByPhase.tsx
+++ b/epictrack-web/src/components/insights/Work/Tabs/General/charts/AssessmentByPhase.tsx
@@ -1,48 +1,42 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { Grid } from "@mui/material";
 import { ETCaption1, ETCaption3, GrayBox } from "components/shared";
 import { PieChart, Pie, Cell, Legend, Tooltip } from "recharts";
 import { getChartColor } from "components/insights/utils";
-import { PieChartData } from "models/insights";
+import { AssessmentByPhase } from "models/insights";
+import PieChartSkeleton from "./PieChartSkeleton";
+import { useGetAssessmentsByPhaseQuery } from "services/rtkQuery/insights";
 import { showNotification } from "components/shared/notificationProvider";
 import { COMMON_ERROR_MESSAGE } from "constants/application-constant";
-import { getAssessmentByPhase } from "services/insightService";
-import PieChartSkeleton from "./PieChartSkeleton";
 
-const AssessmentByPhase = () => {
-  const [chartData, setChartData] = useState<PieChartData[]>([]);
-  const [loading, setLoading] = useState(true);
+const AssessmentByPhaseChart = () => {
+  const {
+    data,
+    error,
+    isLoading: isChartLoading,
+  } = useGetAssessmentsByPhaseQuery();
 
-  const loadData = async () => {
-    setLoading(true);
-    try {
-      const response = await getAssessmentByPhase();
-      if (response) {
-        console.log(response.data);
-        const data = response.data.map((item) => {
-          return {
-            name: item.phase,
-            value: item.count,
-          };
-        });
-        setChartData(data);
-        setLoading(false);
-      }
-    } catch (error) {
-      showNotification(COMMON_ERROR_MESSAGE, {
-        type: "error",
-      });
-      setLoading(false);
-    }
+  const formatData = (data?: AssessmentByPhase[]) => {
+    if (!data) return [];
+    return data.map((item) => {
+      return {
+        name: item.phase,
+        value: item.count,
+        id: item.phase_id,
+      };
+    });
   };
 
-  useEffect(() => {
-    loadData();
-  }, []);
-
-  if (loading) {
+  if (isChartLoading) {
     return <PieChartSkeleton />;
   }
+
+  if (error) {
+    showNotification(COMMON_ERROR_MESSAGE, { type: "error" });
+    return <div>Error</div>;
+  }
+
+  const chartData = formatData(data);
 
   return (
     <GrayBox>
@@ -69,7 +63,7 @@ const AssessmentByPhase = () => {
               isAnimationActive={false}
             >
               {chartData.map((entry, index) => (
-                <Cell key={`cell-${index}`} fill={getChartColor(index)} />
+                <Cell key={`cell-${entry.id}`} fill={getChartColor(index)} />
               ))}
             </Pie>
             <Legend
@@ -89,4 +83,4 @@ const AssessmentByPhase = () => {
   );
 };
 
-export default AssessmentByPhase;
+export default AssessmentByPhaseChart;

--- a/epictrack-web/src/components/insights/Work/Tabs/General/charts/WorkByType.tsx
+++ b/epictrack-web/src/components/insights/Work/Tabs/General/charts/WorkByType.tsx
@@ -49,7 +49,7 @@ const WorkByTypeChart = () => {
           </ETCaption3>
         </Grid>
         <Grid item xs={12} container justifyContent={"center"}>
-          <PieChart width={500} height={300}>
+          <PieChart width={600} height={300}>
             <Pie
               data={formatData(chartData)}
               cx="50%"

--- a/epictrack-web/src/components/insights/Work/Tabs/General/charts/WorkByType.tsx
+++ b/epictrack-web/src/components/insights/Work/Tabs/General/charts/WorkByType.tsx
@@ -1,47 +1,41 @@
-import React, { useEffect, useState } from "react";
-import { Grid, Skeleton } from "@mui/material";
+import React, { useState } from "react";
+import { Grid } from "@mui/material";
 import { ETCaption1, ETCaption3, GrayBox } from "components/shared";
 import { PieChart, Pie, Cell, Legend, Tooltip } from "recharts";
 import { getChartColor } from "components/insights/utils";
-import { getWorkByType } from "services/insightService";
-import { PieChartData } from "models/insights";
 import PieChartSkeleton from "./PieChartSkeleton";
+import { useGetWorksByTypeQuery } from "services/rtkQuery/insights";
+import { WorkByType } from "models/insights";
 import { showNotification } from "components/shared/notificationProvider";
 import { COMMON_ERROR_MESSAGE } from "constants/application-constant";
 
-const WorkByType = () => {
-  const [chartData, setChartData] = useState<PieChartData[]>([]);
-  const [loading, setLoading] = useState(true);
+const WorkByTypeChart = () => {
+  const {
+    data: chartData,
+    error,
+    isLoading: isChartLoading,
+  } = useGetWorksByTypeQuery();
 
-  const loadData = async () => {
-    setLoading(true);
-    try {
-      const response = await getWorkByType();
-      if (response) {
-        const data = response.data.map((item) => {
-          return {
-            name: item.work_type,
-            value: item.count,
-          };
-        });
-        setChartData(data);
-        setLoading(false);
-      }
-    } catch (error) {
-      showNotification(COMMON_ERROR_MESSAGE, {
-        type: "error",
-      });
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    loadData();
-  }, []);
-
-  if (loading) {
+  if (isChartLoading || !chartData) {
     return <PieChartSkeleton />;
   }
+
+  // TODO: handle error
+  if (error) {
+    showNotification(COMMON_ERROR_MESSAGE, { type: "error" });
+    return <div>Error</div>;
+  }
+
+  const formatData = (data: WorkByType[]) => {
+    if (!data) return [];
+    return data.map((item) => {
+      return {
+        name: item.work_type,
+        value: item.count,
+        id: item.work_type_id,
+      };
+    });
+  };
 
   return (
     <GrayBox>
@@ -57,7 +51,7 @@ const WorkByType = () => {
         <Grid item xs={12} container justifyContent={"center"}>
           <PieChart width={500} height={300}>
             <Pie
-              data={chartData}
+              data={formatData(chartData)}
               cx="50%"
               cy="50%"
               outerRadius={80}
@@ -66,8 +60,8 @@ const WorkByType = () => {
               label
               isAnimationActive={false}
             >
-              {chartData.map((entry, index) => (
-                <Cell key={`cell-${index}`} fill={getChartColor(index)} />
+              {formatData(chartData).map((entry, index) => (
+                <Cell key={`cell-${entry.id}`} fill={getChartColor(index)} />
               ))}
             </Pie>
             <Legend
@@ -87,4 +81,4 @@ const WorkByType = () => {
   );
 };
 
-export default WorkByType;
+export default WorkByTypeChart;

--- a/epictrack-web/src/components/insights/Work/Tabs/General/charts/workListing.tsx
+++ b/epictrack-web/src/components/insights/Work/Tabs/General/charts/workListing.tsx
@@ -5,7 +5,10 @@ import { useAppSelector } from "hooks";
 import { hasPermission } from "components/shared/restricted";
 import { ROLES } from "constants/application-constant";
 import { Work } from "models/work";
-import { getSelectFilterOptions } from "components/shared/MasterTrackTable/utils";
+import {
+  getSelectFilterOptions,
+  rowsPerPageOptions,
+} from "components/shared/MasterTrackTable/utils";
 import { ETGridTitle } from "components/shared";
 import { searchFilter } from "components/shared/MasterTrackTable/filters";
 import TableFilter from "components/shared/filterSelect/TableFilter";
@@ -18,6 +21,10 @@ const WorkList = () => {
   const [workTypes, setWorkTypes] = React.useState<string[]>([]);
   const [projects, setProjects] = React.useState<string[]>([]);
   const [ministries, setMinistries] = React.useState<string[]>([]);
+  const [pagination, setPagination] = React.useState({
+    pageIndex: 0,
+    pageSize: 10,
+  });
 
   const { roles } = useAppSelector((state) => state.user.userDetail);
   const canEdit = hasPermission({ roles, allowed: [ROLES.EDIT] });
@@ -25,6 +32,13 @@ const WorkList = () => {
   const { data, error, isLoading } = useGetWorksQuery();
 
   const works = data || [];
+
+  useEffect(() => {
+    setPagination((prev) => ({
+      ...prev,
+      pageSize: works.length,
+    }));
+  }, [works]);
 
   const codeTypes: { [x: string]: any } = {
     work_type: setWorkTypes,
@@ -232,8 +246,13 @@ const WorkList = () => {
       state={{
         isLoading: isLoading,
         showGlobalFilter: true,
+        pagination: pagination,
       }}
       enablePagination
+      muiPaginationProps={{
+        rowsPerPageOptions: rowsPerPageOptions(works.length),
+      }}
+      onPaginationChange={setPagination}
     />
   );
 };

--- a/epictrack-web/src/components/insights/Work/WorkInsightsContext.tsx
+++ b/epictrack-web/src/components/insights/Work/WorkInsightsContext.tsx
@@ -19,7 +19,7 @@ const WorkInsightsContextProvider: React.FC<
   WorkInsightsContextProviderProps
 > = ({ children }) => {
   const [activeTab, setActiveTab] = useState<WorkInsightsTab>(
-    WORK_INSIGHTS_TAB.Staff
+    WORK_INSIGHTS_TAB.General
   );
 
   return (

--- a/epictrack-web/src/services/rtkQuery/insights.tsx
+++ b/epictrack-web/src/services/rtkQuery/insights.tsx
@@ -1,0 +1,66 @@
+// Need to use the React-specific entry point to import createApi
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+import { AppConfig } from "config";
+import { AssessmentByPhase, WorkByType } from "models/insights";
+import { prepareHeaders } from "./util";
+import { Work } from "models/work";
+
+// Define a service using a base URL and expected endpoints
+export const insightsApi = createApi({
+  tagTypes: ["Works"],
+  reducerPath: "insightsApi",
+  baseQuery: fetchBaseQuery({
+    baseUrl: AppConfig.apiUrl,
+    prepareHeaders,
+  }),
+  endpoints: (builder) => ({
+    getWorksByType: builder.query<WorkByType[], void>({
+      query: () => `insights/works?group_by=type`,
+      providesTags: (result) =>
+        result
+          ? [
+              ...result.map(({ work_type_id }) => ({
+                type: "Works" as const,
+                id: work_type_id,
+              })),
+              { type: "Works", id: "LIST" },
+            ]
+          : [{ type: "Works", id: "LIST" }],
+    }),
+    getAssessmentsByPhase: builder.query<AssessmentByPhase[], void>({
+      query: () => `insights/works?group_by=assessment_by_phase`,
+      providesTags: (result) =>
+        result
+          ? [
+              ...result.map(({ phase_id }) => ({
+                type: "Works" as const,
+                id: phase_id,
+              })),
+              { type: "Works", id: "LIST" },
+            ]
+          : [{ type: "Works", id: "LIST" }],
+    }),
+    getWorks: builder.query<Work[], void>({
+      query: () => `works`,
+      providesTags: (result) =>
+        result
+          ? [
+              ...result.map(({ id }) => ({
+                type: "Works" as const,
+                id,
+              })),
+              { type: "Works", id: "LIST" },
+            ]
+          : [{ type: "Works", id: "LIST" }],
+    }),
+  }),
+  keepUnusedDataFor: 300, // in seconds, 300 seconds = 5 minutes
+});
+
+// Export hooks for usage in functional components, which are
+// auto-generated based on the defined endpoints
+export const {
+  useGetWorksByTypeQuery,
+  useGetAssessmentsByPhaseQuery,
+  useGetWorksQuery,
+} = insightsApi;

--- a/epictrack-web/src/services/rtkQuery/insights.tsx
+++ b/epictrack-web/src/services/rtkQuery/insights.tsx
@@ -54,7 +54,7 @@ export const insightsApi = createApi({
           : [{ type: "Works", id: "LIST" }],
     }),
   }),
-  keepUnusedDataFor: 300, // in seconds, 300 seconds = 5 minutes
+  refetchOnMountOrArgChange: 300,
 });
 
 // Export hooks for usage in functional components, which are

--- a/epictrack-web/src/services/rtkQuery/util.ts
+++ b/epictrack-web/src/services/rtkQuery/util.ts
@@ -1,0 +1,6 @@
+import UserService from "services/userService";
+
+export const prepareHeaders = (headers: Headers) => {
+  headers.set("authorization", `Bearer ${UserService.getToken()}`);
+  return headers;
+};

--- a/epictrack-web/src/store.ts
+++ b/epictrack-web/src/store.ts
@@ -3,17 +3,19 @@ import userSlice from "./services/userService/userSlice";
 import { setupListeners } from "@reduxjs/toolkit/query";
 import uiStateSlice from "./styles/uiStateSlice";
 import loadingSlice from "./services/loadingService";
+import { insightsApi } from "services/rtkQuery/insights";
 
 export const store = configureStore({
   reducer: {
     user: userSlice,
     uiState: uiStateSlice,
     loadingState: loadingSlice,
+    [insightsApi.reducerPath]: insightsApi.reducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({
       serializableCheck: false,
-    }),
+    }).concat(insightsApi.middleware),
 });
 
 // optional, but required for refetchOnFocus/refetchOnReconnect behaviors


### PR DESCRIPTION
https://app.zenhub.com/workspaces/epictrack-63891ea941d309001fa292cf/issues/gh/bcgov/epic.track/1926

Details:
- Add insights Redux rtk api
- Cache getWorksByType
- Cache getAssessmentsByPhase
- Cache getWorks
- set Cache to 5 minutes