### PR TITLE
30-60-90 - Status location

### DIFF
--- a/epictrack-web/src/components/reports/30-60-90Report/ThirtySixtyNinety.tsx
+++ b/epictrack-web/src/components/reports/30-60-90Report/ThirtySixtyNinety.tsx
@@ -207,10 +207,10 @@ export default function ThirtySixtyNinety() {
                             <TabPanel value={selectedTab} index={1}>
                               {item["work_short_description"]}
                             </TabPanel>
-                            <TabPanel value={selectedTab} index={1}>
+                            <TabPanel value={selectedTab} index={2}>
                               {item["work_status_text"]}
                             </TabPanel>
-                            <TabPanel value={selectedTab} index={1}>
+                            <TabPanel value={selectedTab} index={3}>
                               {item["decision_information"]}
                             </TabPanel>
                           </AccordionDetails>


### PR DESCRIPTION
#1933 - Fixed issue where status updates & decision information was shown under work short description instead of the respective tabs.