### PR TITLE
Fix work dialog is closed when backend error occurs

### DIFF
--- a/epictrack-web/src/components/work/Dialog/index.tsx
+++ b/epictrack-web/src/components/work/Dialog/index.tsx
@@ -40,41 +40,27 @@ export const WorkDialog = ({
   };
 
   const createWork = async (data: any) => {
-    try {
-      await workService.create(data);
-      showNotification("Work created successfully", {
-        type: "success",
-      });
-      setWork(null);
-    } catch (error) {
-      showNotification("Could not create Work", {
-        type: "error",
-      });
-    }
+    await workService.create(data);
   };
 
   const editWork = async (data: any) => {
-    try {
-      await workService.update(data, String(workId));
-      showNotification("Work updated successfully", {
-        type: "success",
-      });
-      setWork(null);
-    } catch (error) {
-      showNotification("Could not update Work", {
-        type: "error",
-      });
-    }
+    await workService.update(data, String(workId));
   };
 
   const saveWork = async (data: any) => {
-    if (workId) {
-      await editWork(data);
-    } else {
-      await createWork(data);
+    try {
+      workId ? await editWork(data) : await createWork(data);
+      showNotification("Work saved successfully", {
+        type: "success",
+      });
+      setOpen(false);
+      setWork(null);
+      saveWorkCallback();
+    } catch (error) {
+      showNotification("Could not save Work", {
+        type: "error",
+      });
     }
-    setOpen(false);
-    saveWorkCallback();
   };
 
   useEffect(() => {


### PR DESCRIPTION
https://app.zenhub.com/workspaces/epictrack-63891ea941d309001fa292cf/issues/gh/bcgov/epic.track/1920

Details:
- Close the work form dialog only in the try block