### PR TITLE
sort workplans by start date in descending order

### DIFF
--- a/epictrack-api/src/api/models/work.py
+++ b/epictrack-api/src/api/models/work.py
@@ -125,6 +125,8 @@ class Work(BaseModelVersioned):
 
         query = cls.filter_by_search_criteria(query, search_filters)
 
+        query = query.order_by(Work.start_date.desc())
+
         no_pagination_options = not pagination_options or not pagination_options.page or not pagination_options.size
         if no_pagination_options:
             items = query.all()

--- a/epictrack-api/src/api/models/work.py
+++ b/epictrack-api/src/api/models/work.py
@@ -125,7 +125,7 @@ class Work(BaseModelVersioned):
 
         query = cls.filter_by_search_criteria(query, search_filters)
 
-        query = query.order_by(Work.start_date.desc())
+        query = query.order_by(Work.start_date.desc(), Work.title)
 
         no_pagination_options = not pagination_options or not pagination_options.page or not pagination_options.size
         if no_pagination_options:


### PR DESCRIPTION
https://app.zenhub.com/workspaces/epictrack-63891ea941d309001fa292cf/issues/gh/bcgov/epic.track/1927

Details:
- add order by to workplans query by start date descending and secondary sort by title alphabetically