### PR TITLE
Fetch only active team lead staff and prevent lead duplication

### DIFF
--- a/epictrack-api/src/api/models/staff_work_role.py
+++ b/epictrack-api/src/api/models/staff_work_role.py
@@ -51,7 +51,7 @@ class StaffWorkRole(BaseModelVersioned):
     @classmethod
     def find_by_role_and_work(cls, work_id: int, role_id):
         """Return by work and role ids."""
-        return cls.query(StaffWorkRole).filter(
+        return cls.query.filter(
             StaffWorkRole.work_id == work_id,
             StaffWorkRole.role_id == role_id,
             StaffWorkRole.is_deleted.is_(False),
@@ -59,9 +59,9 @@ class StaffWorkRole(BaseModelVersioned):
         ).all()
 
     @classmethod
-    def find_by_work_and_staff_and_role(cls, work_id: int, staff_id, role_id, work_staff_id):
-        """Return by work and role ids."""
-        query = cls.query(StaffWorkRole).filter(
+    def find_by_work_and_staff_and_role(cls, work_id: int, staff_id: object, role_id: object, work_staff_id: object):
+        """Return by work, staff and role ids."""
+        query = cls.query.filter(
             StaffWorkRole.work_id == work_id,
             StaffWorkRole.staff_id == staff_id,
             StaffWorkRole.is_deleted.is_(False),

--- a/epictrack-api/src/api/models/staff_work_role.py
+++ b/epictrack-api/src/api/models/staff_work_role.py
@@ -57,3 +57,18 @@ class StaffWorkRole(BaseModelVersioned):
             StaffWorkRole.is_deleted.is_(False),
             StaffWorkRole.is_active.is_(True),
         ).first()
+
+    @classmethod
+    def find_by_work_and_staff_and_role(cls, work_id: int, staff_id, role_id, work_staff_id):
+        """Return by work and role ids."""
+        query = cls.query(StaffWorkRole).filter(
+            StaffWorkRole.work_id == work_id,
+            StaffWorkRole.staff_id == staff_id,
+            StaffWorkRole.is_deleted.is_(False),
+            StaffWorkRole.role_id == role_id,
+        )
+
+        if work_staff_id:
+            query = query.filter(StaffWorkRole.id != work_staff_id)
+
+        return query.all()

--- a/epictrack-api/src/api/models/staff_work_role.py
+++ b/epictrack-api/src/api/models/staff_work_role.py
@@ -47,3 +47,13 @@ class StaffWorkRole(BaseModelVersioned):
     def find_by_work_id(cls, work_id: int):
         """Return by work id."""
         return cls.query.filter_by(work_id=work_id)
+
+    @classmethod
+    def find_by_role_and_work(cls, work_id: int, role_id):
+        """Return by work and role ids."""
+        return cls.query(StaffWorkRole).filter(
+            StaffWorkRole.work_id == work_id,
+            StaffWorkRole.role_id == role_id,
+            StaffWorkRole.is_deleted.is_(False),
+            StaffWorkRole.is_active.is_(True),
+        ).first()

--- a/epictrack-api/src/api/models/staff_work_role.py
+++ b/epictrack-api/src/api/models/staff_work_role.py
@@ -56,7 +56,7 @@ class StaffWorkRole(BaseModelVersioned):
             StaffWorkRole.role_id == role_id,
             StaffWorkRole.is_deleted.is_(False),
             StaffWorkRole.is_active.is_(True),
-        ).first()
+        ).all()
 
     @classmethod
     def find_by_work_and_staff_and_role(cls, work_id: int, staff_id, role_id, work_staff_id):

--- a/epictrack-api/src/api/services/work.py
+++ b/epictrack-api/src/api/services/work.py
@@ -367,15 +367,9 @@ class WorkService:  # pylint: disable=too-many-public-methods
         cls, work_id: int, staff_id: int, role_id: int, work_staff_id: int = None
     ):
         """Check the existence of staff in work"""
-        query = db.session.query(StaffWorkRole).filter(
-            StaffWorkRole.work_id == work_id,
-            StaffWorkRole.staff_id == staff_id,
-            StaffWorkRole.is_deleted.is_(False),
-            StaffWorkRole.role_id == role_id,
-        )
-        if work_staff_id:
-            query = query.filter(StaffWorkRole.id != work_staff_id)
-        if query.count() > 0:
+        staff_work_roles = StaffWorkRole.find_by_work_and_staff_and_role(
+            work_id, staff_id, role_id, work_staff_id)
+        if staff_work_roles:
             raise ResourceExistsError("Staff Work association already exists")
 
     @classmethod
@@ -386,7 +380,6 @@ class WorkService:  # pylint: disable=too-many-public-methods
         if role_id != Membership.LEAD:
             return
         staff_work_role = StaffWorkRole.find_by_role_and_work(work_id, role_id)
-
         if staff_work_role:
             raise ResourceExistsError("This work already has a active Team Lead")
 

--- a/epictrack-api/src/api/services/work.py
+++ b/epictrack-api/src/api/services/work.py
@@ -606,9 +606,9 @@ class WorkService:  # pylint: disable=too-many-public-methods
 
         file_buffer = BytesIO()
         columns = ["name", "type", "start_date", "end_date", "days", "assigned",
-            "responsibility", "notes", "progress"]
+                   "responsibility", "notes", "progress"]
         headers = ["Name", "Type", "Start Date", "End Date", "Days", "Assigned",
-            "Responsibility", "Notes", "Progress"]
+                   "Responsibility", "Notes", "Progress"]
         data.to_excel(file_buffer, index=False, columns=columns, header=headers)
         file_buffer.seek(0, 0)
         return file_buffer.getvalue()

--- a/epictrack-api/src/api/services/work.py
+++ b/epictrack-api/src/api/services/work.py
@@ -365,11 +365,22 @@ class WorkService:  # pylint: disable=too-many-public-methods
     @classmethod
     def check_work_staff_existence(
         cls, work_id: int, staff_id: int, role_id: int, work_staff_id: int = None
-    ):
+    ) -> bool:
         """Check the existence of staff in work"""
         staff_work_roles = StaffWorkRole.find_by_work_and_staff_and_role(
             work_id, staff_id, role_id, work_staff_id)
         if staff_work_roles:
+            return True
+        return False
+
+    @classmethod
+    def check_work_staff_existence_duplication(
+        cls, work_id: int, staff_id: int, role_id: int, work_staff_id: int = None
+    ):
+        """Check the existence of staff in work"""
+        exists = cls.check_work_staff_existence(
+            work_id, staff_id, role_id, work_staff_id)
+        if exists:
             raise ResourceExistsError("Staff Work association already exists")
 
     @classmethod
@@ -388,7 +399,7 @@ class WorkService:  # pylint: disable=too-many-public-methods
         cls, work_id: int, data: dict, commit: bool = True
     ) -> StaffWorkRole:
         """Create Staff Work"""
-        cls.check_work_staff_existence(
+        cls.check_work_staff_existence_duplication(
             work_id, data.get("staff_id"), data.get("role_id")
         )
         cls.check_valid_role_association(work_id, data.get("role_id"))
@@ -421,7 +432,7 @@ class WorkService:  # pylint: disable=too-many-public-methods
         if not work_staff:
             raise ResourceNotFoundError("No staff work association found")
 
-        cls.check_work_staff_existence(
+        cls.check_work_staff_existence_duplication(
             work_staff.work_id, data.get("staff_id"), data.get("role_id"), work_staff_id
         )
         cls.check_valid_role_association(work_staff.work_id, data.get("role_id"))

--- a/epictrack-api/src/api/services/work.py
+++ b/epictrack-api/src/api/services/work.py
@@ -605,28 +605,10 @@ class WorkService:  # pylint: disable=too-many-public-methods
         # unsupported-assignment-operation
 
         file_buffer = BytesIO()
-        columns = [
-            "name",
-            "type",
-            "start_date",
-            "end_date",
-            "days",
-            "assigned",
-            "responsibility",
-            "notes",
-            "progress",
-        ]
-        headers = [
-            "Name",
-            "Type",
-            "Start Date",
-            "End Date",
-            "Days",
-            "Assigned",
-            "Responsibility",
-            "Notes",
-            "Progress",
-        ]
+        columns = ["name", "type", "start_date", "end_date", "days", "assigned",
+            "responsibility", "notes", "progress"]
+        headers = ["Name", "Type", "Start Date", "End Date", "Days", "Assigned",
+            "Responsibility", "Notes", "Progress"]
         data.to_excel(file_buffer, index=False, columns=columns, header=headers)
         file_buffer.seek(0, 0)
         return file_buffer.getvalue()

--- a/epictrack-api/src/api/services/work.py
+++ b/epictrack-api/src/api/services/work.py
@@ -377,10 +377,10 @@ class WorkService:  # pylint: disable=too-many-public-methods
         cls, work_id: int, role_id: int
     ):
         """Check the existence of staff in work"""
-        if role_id != Membership.LEAD:
+        if role_id != Membership.LEAD.value:
             return
-        staff_work_role = StaffWorkRole.find_by_role_and_work(work_id, role_id)
-        if staff_work_role:
+        staff_work_roles = StaffWorkRole.find_by_role_and_work(work_id, role_id)
+        if staff_work_roles:
             raise ResourceExistsError("This work already has a active Team Lead")
 
     @classmethod

--- a/epictrack-web/src/components/myWorkplans/Card/CardFooter.tsx
+++ b/epictrack-web/src/components/myWorkplans/Card/CardFooter.tsx
@@ -1,11 +1,9 @@
+import React from "react";
 import { Button, Grid } from "@mui/material";
 import { Palette } from "../../../styles/theme";
-import { ETCaption1, ETCaption2, ETParagraph } from "../../shared";
-import Icons from "../../icons";
-import { IconProps } from "../../icons/type";
+import { ETCaption1, ETParagraph } from "../../shared";
 import { CardProps } from "./type";
 import { useNavigate } from "react-router-dom";
-import React from "react";
 import StaffGroup from "./Staff/StaffGroup";
 
 const CardFooter = ({ workplan }: CardProps) => {

--- a/epictrack-web/src/components/workPlan/team/TeamForm.tsx
+++ b/epictrack-web/src/components/workPlan/team/TeamForm.tsx
@@ -131,40 +131,26 @@ const TeamForm = ({ onSave, workStaffId }: TeamFormProps) => {
     handleSubmit,
     formState: { errors },
     reset,
-    control,
   } = methods;
+
+  const saveTeamMember = (data: StaffWorkRole) => {
+    if (workStaffId) {
+      return workService.updateWorkStaff(data, Number(workStaffId));
+    }
+    return workService.createWorkStaff(data, Number(ctx.work?.id));
+  };
 
   const onSubmitHandler = async (data: StaffWorkRole) => {
     try {
-      if (workStaffId) {
-        const createResult = await workService.updateWorkStaff(
-          data,
-          Number(workStaffId)
-        );
-        if (createResult.status === 200) {
-          showNotification("Team details updated", {
-            type: "success",
-          });
-          if (onSave) {
-            onSave();
-          }
-        }
-      } else {
-        const createResult = await workService.createWorkStaff(
-          data,
-          Number(ctx.work?.id)
-        );
-        if (createResult.status === 201) {
-          showNotification("Team details inserted", {
-            type: "success",
-          });
-          if (onSave) {
-            onSave();
-          }
-        }
+      await saveTeamMember(data);
+      showNotification("Team details saved", {
+        type: "success",
+      });
+      if (onSave) {
+        onSave();
       }
-    } catch (e: any) {
-      const message = getErrorMessage(e);
+    } catch (error: any) {
+      const message = getErrorMessage(error);
       showNotification(message, {
         type: "error",
       });


### PR DESCRIPTION
https://app.zenhub.com/workspaces/epictrack-63891ea941d309001fa292cf/issues/gh/bcgov/epic.track/2004

Details:
- Add a backend check to prevent team lead duplication
- Only fetch active staff for work staff info in Work Cards