### PR TITLE
Remove double import of snackbar

### DIFF
--- a/epictrack-web/cypress/support/component.tsx
+++ b/epictrack-web/cypress/support/component.tsx
@@ -20,7 +20,6 @@ import { MemoryRouterProps } from "react-router-dom";
 import { SnackbarProvider } from "notistack";
 import { EnhancedStore } from "@reduxjs/toolkit";
 import { RootState, store } from "../../src/store";
-import { SnackbarProvider } from "notistack";
 // Alternatively you can use CommonJS syntax:
 // require("./commands")
 


### PR DESCRIPTION
https://app.zenhub.com/workspaces/epictrack-63891ea941d309001fa292cf/issues/gh/bcgov/epic.track/2013

Details:
for some reason import { SnackbarProvider } from "notistack"; was duplicated in cypress/support/component.tsx which was causing all tests to fail