### PR TITLE
Sort my workplans by start date descending

### DIFF
--- a/epictrack-api/src/api/models/work.py
+++ b/epictrack-api/src/api/models/work.py
@@ -128,7 +128,7 @@ class Work(BaseModelVersioned):
 
         query = cls.filter_by_search_criteria(query, search_filters)
 
-        query = query.order_by(Work.title)
+        query = query.order_by(Work.start_date.desc())
 
         no_pagination_options = not pagination_options or not pagination_options.page or not pagination_options.size
         if no_pagination_options:


### PR DESCRIPTION
https://app.zenhub.com/workspaces/epictrack-63891ea941d309001fa292cf/issues/gh/bcgov/epic.track/1927

Details:
- change order_by to start_date.desc()