### PR TITLE
Keep query params unaffected

### DIFF
--- a/epictrack-web/src/components/workPlan/WorkPlanContainer.tsx
+++ b/epictrack-web/src/components/workPlan/WorkPlanContainer.tsx
@@ -47,7 +47,7 @@ const WorkPlanContainer = () => {
     const currentTabLabel = Object.values(WORKPLAN_TAB).find(
       (tab) => tab.index === selectedTabIndex
     )?.label;
-    navigate(`${location.pathname}${location.search ?? ""}`, {
+    navigate(`${location.pathname}${location.search}`, {
       state: { tab: currentTabLabel },
     });
   }, [selectedTabIndex]);

--- a/epictrack-web/src/components/workPlan/WorkPlanContainer.tsx
+++ b/epictrack-web/src/components/workPlan/WorkPlanContainer.tsx
@@ -47,7 +47,9 @@ const WorkPlanContainer = () => {
     const currentTabLabel = Object.values(WORKPLAN_TAB).find(
       (tab) => tab.index === selectedTabIndex
     )?.label;
-    navigate(".", { state: { tab: currentTabLabel } });
+    navigate(`${location.pathname}${location.search ?? ""}`, {
+      state: { tab: currentTabLabel },
+    });
   }, [selectedTabIndex]);
 
   if (ctx.loading) {


### PR DESCRIPTION
https://app.zenhub.com/workspaces/epictrack-63891ea941d309001fa292cf/issues/gh/bcgov/epic.track/2035

Details:
- Keep the query params when using navigate to add tab value to location state