### PR TITLE
lower nav open button so it is not overlayed when the env banner

### DIFF
--- a/epictrack-web/src/components/layout/SideNav/NavOpenButton.tsx
+++ b/epictrack-web/src/components/layout/SideNav/NavOpenButton.tsx
@@ -1,13 +1,7 @@
 import React from "react";
-import {
-  Box,
-  BoxProps,
-  CSSObject,
-  Theme,
-  styled,
-  useTheme,
-} from "@mui/material";
+import { Box, BoxProps, styled, useTheme } from "@mui/material";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import { useAppDispatch, useAppSelector } from "hooks";
 import { Palette } from "styles/theme";
 import { toggleDrawer } from "styles/uiStateSlice";
@@ -23,7 +17,7 @@ const DrawerToggleButton = styled(PlainDrawerToggleButton, {
   shouldForwardProp: (prop) => prop !== "open",
 })(({ theme }) => ({
   zIndex: theme.zIndex.drawer,
-  top: 85,
+  top: 110,
   height: 48,
   width: 32,
   backgroundColor: Palette.primary.main,
@@ -72,7 +66,11 @@ const NavOpenButton = () => {
         }}
         onClick={handleToggleDrawer}
       >
-        <ChevronRightIcon fontSize="large" />
+        {isDrawerExpanded ? (
+          <ChevronLeftIcon fontSize="large" />
+        ) : (
+          <ChevronRightIcon fontSize="large" />
+        )}
       </DrawerToggleButton>
     </Box>
   );


### PR DESCRIPTION
https://app.zenhub.com/workspaces/epictrack-63891ea941d309001fa292cf/issues/gh/bcgov/epic.track/2057

Details:
- the side nav open close button was hidden under the env banner so I lowered it a bit