### PR TITLE
Navigate to help page according to work type

### DIFF
--- a/epictrack-web/src/components/AppHelpButton/HelpPageMap.json
+++ b/epictrack-web/src/components/AppHelpButton/HelpPageMap.json
@@ -50,17 +50,17 @@
       },
       {
         "epicTrackPath": "/work-plan",
-        "helpPage": "https://intranet.qa.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/project-notification",
+        "helpPage": "https://intranet.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/project-notification",
         "tags": ["Project Notification"]
       },
       {
         "epicTrackPath": "/work-plan",
-        "helpPage": "https://intranet.qa.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/minister-s-designation",
+        "helpPage": "https://intranet.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/minister-s-designation",
         "tags": ["Minister's Designation"]
       },
       {
         "epicTrackPath": "/work-plan",
-        "helpPage": "https://intranet.qa.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/ceao-s-designation",
+        "helpPage": "https://intranet.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/ceao-s-designation",
         "tags": ["CEAO's Designation"]
       },
       {
@@ -70,52 +70,52 @@
       },
       {
         "epicTrackPath": "/work-plan",
-        "helpPage": "https://intranet.qa.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/exemption-request",
+        "helpPage": "https://intranet.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/exemption-request",
         "tags": ["Exemption Order"]
       },
       {
         "epicTrackPath": "/work-plan",
-        "helpPage": "https://intranet.qa.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/eac-assessment",
+        "helpPage": "https://intranet.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/eac-assessment",
         "tags": ["Assessment"]
       },
       {
         "epicTrackPath": "/work-plan",
-        "helpPage": "https://intranet.qa.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/amendment-complex",
+        "helpPage": "https://intranet.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/amendment-complex",
         "tags": ["Amendment"]
       },
       {
         "epicTrackPath": "/work-plan",
-        "helpPage": "https://intranet.qa.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/document-review",
+        "helpPage": "https://intranet.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/document-review",
         "tags": ["Post-EAC Document Review"]
       },
       {
         "epicTrackPath": "/work-plan",
-        "helpPage": "https://intranet.qa.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/eac-extension",
+        "helpPage": "https://intranet.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/eac-extension",
         "tags": ["EAC Extension"]
       },
       {
         "epicTrackPath": "/work-plan",
-        "helpPage": "https://intranet.qa.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/substantial-start-decision",
+        "helpPage": "https://intranet.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/substantial-start-decision",
         "tags": ["Substantial Start Decision"]
       },
       {
         "epicTrackPath": "/work-plan",
-        "helpPage": "https://intranet.qa.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/eac-order-transfer",
+        "helpPage": "https://intranet.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/eac-order-transfer",
         "tags": ["EAC/Order Transfer"]
       },
       {
         "epicTrackPath": "/work-plan",
-        "helpPage": "https://intranet.qa.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/eac-order-suspension",
+        "helpPage": "https://intranet.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/eac-order-suspension",
         "tags": ["EAC/Order Suspension"]
       },
       {
         "epicTrackPath": "/work-plan",
-        "helpPage": "https://intranet.qa.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/eac-order-cancellation",
+        "helpPage": "https://intranet.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/eac-order-cancellation",
         "tags": ["EAC/Order Cancellation"]
       },
       {
         "epicTrackPath": "/work-plan",
-        "helpPage": "https://intranet.qa.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/other",
+        "helpPage": "https://intranet.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/other",
         "tags": ["Other"]
       },
       {

--- a/epictrack-web/src/components/AppHelpButton/HelpPageMap.json
+++ b/epictrack-web/src/components/AppHelpButton/HelpPageMap.json
@@ -21,34 +21,103 @@
       {
         "epicTrackPath": "/work-plan",
         "helpPage": "https://intranet.gov.bc.ca/intranet/content?id=A35C49D2D60144F594F8C1DDB5F0EA10#workplan",
-        "tags": ["workplan"]
+        "tags": ["Workplan"]
       },
       {
         "epicTrackPath": "/work-plan",
         "helpPage": "https://intranet.gov.bc.ca/intranet/content?id=A35C49D2D60144F594F8C1DDB5F0EA10#status",
-        "tags": ["status"]
+        "tags": ["Status"]
       },
       {
         "epicTrackPath": "/work-plan",
         "helpPage": "https://intranet.gov.bc.ca/intranet/content?id=A35C49D2D60144F594F8C1DDB5F0EA10#issues",
-        "tags": ["issues"]
+        "tags": ["Issues"]
       },
       {
         "epicTrackPath": "/work-plan",
         "helpPage": "https://intranet.gov.bc.ca/intranet/content?id=A35C49D2D60144F594F8C1DDB5F0EA10#about",
-        "tags": ["about"]
+        "tags": ["About"]
       },
       {
         "epicTrackPath": "/work-plan",
         "helpPage": "https://intranet.gov.bc.ca/intranet/content?id=A35C49D2D60144F594F8C1DDB5F0EA10#teams",
-        "tags": ["team"]
+        "tags": ["Team"]
       },
       {
         "epicTrackPath": "/work-plan",
         "helpPage": "https://intranet.gov.bc.ca/intranet/content?id=A35C49D2D60144F594F8C1DDB5F0EA10#firstnations",
-        "tags": ["firstnations"]
+        "tags": ["First Nations"]
       },
-
+      {
+        "epicTrackPath": "/work-plan",
+        "helpPage": "https://intranet.qa.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/project-notification",
+        "tags": ["Project Notification"]
+      },
+      {
+        "epicTrackPath": "/work-plan",
+        "helpPage": "https://intranet.qa.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/minister-s-designation",
+        "tags": ["Minister's Designation"]
+      },
+      {
+        "epicTrackPath": "/work-plan",
+        "helpPage": "https://intranet.qa.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/ceao-s-designation",
+        "tags": ["CEAO's Designation"]
+      },
+      {
+        "epicTrackPath": "/work-plan",
+        "helpPage": "",
+        "tags": ["Intake (Pre-EA)"]
+      },
+      {
+        "epicTrackPath": "/work-plan",
+        "helpPage": "https://intranet.qa.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/exemption-request",
+        "tags": ["Exemption Order"]
+      },
+      {
+        "epicTrackPath": "/work-plan",
+        "helpPage": "https://intranet.qa.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/eac-assessment",
+        "tags": ["Assessment"]
+      },
+      {
+        "epicTrackPath": "/work-plan",
+        "helpPage": "https://intranet.qa.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/amendment-complex",
+        "tags": ["Amendment"]
+      },
+      {
+        "epicTrackPath": "/work-plan",
+        "helpPage": "https://intranet.qa.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/document-review",
+        "tags": ["Post-EAC Document Review"]
+      },
+      {
+        "epicTrackPath": "/work-plan",
+        "helpPage": "https://intranet.qa.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/eac-extension",
+        "tags": ["EAC Extension"]
+      },
+      {
+        "epicTrackPath": "/work-plan",
+        "helpPage": "https://intranet.qa.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/substantial-start-decision",
+        "tags": ["Substantial Start Decision"]
+      },
+      {
+        "epicTrackPath": "/work-plan",
+        "helpPage": "https://intranet.qa.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/eac-order-transfer",
+        "tags": ["EAC/Order Transfer"]
+      },
+      {
+        "epicTrackPath": "/work-plan",
+        "helpPage": "https://intranet.qa.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/eac-order-suspension",
+        "tags": ["EAC/Order Suspension"]
+      },
+      {
+        "epicTrackPath": "/work-plan",
+        "helpPage": "https://intranet.qa.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/eac-order-cancellation",
+        "tags": ["EAC/Order Cancellation"]
+      },
+      {
+        "epicTrackPath": "/work-plan",
+        "helpPage": "https://intranet.qa.gov.bc.ca/eao/digital-services/support-for-epic-system/support-for-epic-track/milestone-definitions/other",
+        "tags": ["Other"]
+      },
       {
         "epicTrackPath": "/reports/referral-schedule",
         "helpPage": "https://intranet.gov.bc.ca/intranet/content?id=FE54F5EFE92B4CF0AC74490E2D03FD4A"

--- a/epictrack-web/src/components/AppHelpButton/SupportCenterMenuItem.tsx
+++ b/epictrack-web/src/components/AppHelpButton/SupportCenterMenuItem.tsx
@@ -45,16 +45,14 @@ const SupportCenterMenuItem = () => {
 
   const findLinkWithTagsOrAny = (matchingLinks: HelpPageLink[]) => {
     const helpPageTags = location.state?.helpPageTags || [];
-    console.log("helpPageTags", helpPageTags);
-    console.log("matchingLinks", matchingLinks);
     if (helpPageTags.length === 0) {
       return matchingLinks[0];
     }
 
     return matchingLinks.find((link: HelpPageLink) => {
+      const linkTags = new Set(link.tags);
       return helpPageTags.every((tag: string) => {
-        const formattedTag = tag.toLocaleLowerCase().replace(" ", "");
-        return link.tags?.includes(formattedTag);
+        return linkTags.has(tag);
       });
     });
   };

--- a/epictrack-web/src/components/user/UserList.tsx
+++ b/epictrack-web/src/components/user/UserList.tsx
@@ -76,7 +76,6 @@ const UserList = () => {
       .filter((p) => userDetails.groups.includes(p.path))
       .sort((a, b) => b.level - a.level)[0];
   }, [userDetails, groups]);
-  console.log(currentUserGroup);
   const columns = React.useMemo<MRT_ColumnDef<User>[]>(
     () => [
       {

--- a/epictrack-web/src/components/workPlan/WorkPlanContainer.tsx
+++ b/epictrack-web/src/components/workPlan/WorkPlanContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from "react";
+import React, { useContext } from "react";
 import { ETCaption3, ETHeading2, ETPageContainer } from "../shared";
 import { Palette } from "../../styles/theme";
 import { Box } from "@mui/system";
@@ -42,13 +42,6 @@ const WorkPlanContainer = () => {
   const handleTabSelected = (_event: React.SyntheticEvent, index: number) => {
     setSelectedTabIndex(index);
   };
-
-  useRouterLocationStateForHelpPage(() => {
-    const currentSelectedTabLabel = Object.values(WORKPLAN_TAB).find(
-      (tab) => tab.index === selectedTabIndex
-    )?.label;
-    return currentSelectedTabLabel;
-  }, [selectedTabIndex]);
 
   if (ctx.loading) {
     return <WorkPlanSkeleton />;

--- a/epictrack-web/src/components/workPlan/about/AboutContext.tsx
+++ b/epictrack-web/src/components/workPlan/about/AboutContext.tsx
@@ -1,5 +1,7 @@
 import React from "react";
+import useRouterLocationStateForHelpPage from "hooks/useRouterLocationStateForHelpPage";
 import { createContext } from "react";
+import { WORKPLAN_TAB } from "../constants";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface AboutContextProps {}
@@ -11,5 +13,6 @@ export const AboutProvider = ({
 }: {
   children: JSX.Element | JSX.Element[];
 }) => {
+  useRouterLocationStateForHelpPage(() => WORKPLAN_TAB.ABOUT.label, []);
   return <AboutContext.Provider value={{}}>{children}</AboutContext.Provider>;
 };

--- a/epictrack-web/src/components/workPlan/firstNations/FirstNationContainer.tsx
+++ b/epictrack-web/src/components/workPlan/firstNations/FirstNationContainer.tsx
@@ -14,6 +14,8 @@ import debounce from "lodash/debounce";
 import workService from "../../../services/workService/workService";
 import { Work } from "../../../models/work";
 import { showNotification } from "../../shared/notificationProvider";
+import useRouterLocationStateForHelpPage from "hooks/useRouterLocationStateForHelpPage";
+import { WORKPLAN_TAB } from "../constants";
 
 const LinkIcon: React.FC<IconProps> = Icons["LinkIcon"];
 
@@ -73,6 +75,8 @@ const FirstNationContainer = () => {
       debounceSave(value);
     }
   };
+
+  useRouterLocationStateForHelpPage(() => WORKPLAN_TAB.FIRST_NATIONS.label, []);
 
   return (
     <Grid container columnSpacing={1.5}>

--- a/epictrack-web/src/components/workPlan/issues/IssuesContext.tsx
+++ b/epictrack-web/src/components/workPlan/issues/IssuesContext.tsx
@@ -6,6 +6,8 @@ import { WorkIssue, WorkIssueUpdate } from "../../../models/Issue";
 import { CloneForm, CreateIssueForm, EditIssueForm } from "./types";
 import { showNotification } from "components/shared/notificationProvider";
 import { getErrorMessage } from "utils/axiosUtils";
+import useRouterLocationStateForHelpPage from "hooks/useRouterLocationStateForHelpPage";
+import { WORKPLAN_TAB } from "../constants";
 
 interface IssuesContextProps {
   isIssuesLoading: boolean;
@@ -245,6 +247,8 @@ export const IssuesProvider = ({
       setIsIssuesLoading(false);
     }
   };
+
+  useRouterLocationStateForHelpPage(() => WORKPLAN_TAB.ISSUES.label, []);
 
   return (
     <IssuesContext.Provider

--- a/epictrack-web/src/components/workPlan/phase/PhaseContainer.tsx
+++ b/epictrack-web/src/components/workPlan/phase/PhaseContainer.tsx
@@ -7,6 +7,8 @@ import { CustomSwitch } from "../../shared/CustomSwitch";
 import { Palette } from "../../../styles/theme";
 import { WorkPhaseAdditionalInfo } from "../../../models/work";
 import { When } from "react-if";
+import useRouterLocationStateForHelpPage from "hooks/useRouterLocationStateForHelpPage";
+import { WORKPLAN_TAB } from "../constants";
 
 const PhaseContainer = () => {
   const ctx = useContext(WorkplanContext);
@@ -42,6 +44,11 @@ const PhaseContainer = () => {
     setCompletedPhases(completedPhases);
     setCurrentAndFuturePhases(currentAndFuturePhases);
   }, [showCompletedPhases, ctx.workPhases]);
+
+  useRouterLocationStateForHelpPage(() => {
+    return ctx.work?.work_type?.name ?? undefined;
+  }, [ctx.work?.work_type_id]);
+
   if (ctx.workPhases.length === 0) {
     return (
       <Box sx={{ display: "flex", flexDirection: "column", gap: "1rem" }}>

--- a/epictrack-web/src/components/workPlan/status/StatusContext.tsx
+++ b/epictrack-web/src/components/workPlan/status/StatusContext.tsx
@@ -8,6 +8,8 @@ import statusService from "../../../services/statusService/statusService";
 import { useSearchParams } from "../../../hooks/useSearchParams";
 import { WorkplanContext } from "../WorkPlanContext";
 import { getErrorMessage } from "../../../utils/axiosUtils";
+import useRouterLocationStateForHelpPage from "hooks/useRouterLocationStateForHelpPage";
+import { WORKPLAN_TAB } from "../constants";
 
 interface StatusContextProps {
   setShowStatusForm: Dispatch<SetStateAction<boolean>>;
@@ -125,6 +127,8 @@ export const StatusProvider = ({
       });
     }
   };
+
+  useRouterLocationStateForHelpPage(() => WORKPLAN_TAB.STATUS.label, []);
 
   return (
     <StatusContext.Provider

--- a/epictrack-web/src/components/workPlan/team/TeamContainer.tsx
+++ b/epictrack-web/src/components/workPlan/team/TeamContainer.tsx
@@ -4,6 +4,8 @@ import { ETHeading3 } from "../../shared";
 import { Palette } from "../../../styles/theme";
 import TeamList from "./TeamList";
 import TeamInfo from "./TeamInfo";
+import useRouterLocationStateForHelpPage from "hooks/useRouterLocationStateForHelpPage";
+import { WORKPLAN_TAB } from "../constants";
 
 const title: SxProps = {
   borderBottom: `2px solid ${Palette.primary.main}`,
@@ -11,6 +13,7 @@ const title: SxProps = {
 };
 
 const TeamContainer = () => {
+  useRouterLocationStateForHelpPage(() => WORKPLAN_TAB.TEAM.label, []);
   return (
     <Grid container columnSpacing={1.5}>
       <Grid item xs={8}>

--- a/epictrack-web/src/hooks/useRouterLocationStateForHelpPage.tsx
+++ b/epictrack-web/src/hooks/useRouterLocationStateForHelpPage.tsx
@@ -9,7 +9,6 @@ const useRouterLocationStateForHelpPage = (
   const location = useLocation();
 
   useEffect(() => {
-    console.log("ran");
     const callBackValue = callback();
 
     let newtags: string[] = [];
@@ -18,8 +17,6 @@ const useRouterLocationStateForHelpPage = (
     } else if (callBackValue) {
       newtags = [callBackValue];
     }
-
-    console.log(newtags);
 
     navigate(`${location.pathname}${location.search}`, {
       state: { helpPageTags: newtags },


### PR DESCRIPTION
https://app.zenhub.com/workspaces/epictrack-63891ea941d309001fa292cf/issues/gh/bcgov/epic.track/2098

Details:
- Add help page links
- handle saving current tab or work type in route state
- handle navigating to help page depending on path and tags (tab value, work type..)