### PR TITLE
data and columns are already stable references

### DIFF
--- a/epictrack-web/src/components/shared/MasterTrackTable/index.tsx
+++ b/epictrack-web/src/components/shared/MasterTrackTable/index.tsx
@@ -207,7 +207,7 @@ const MasterTrackTable = <TData extends MRT_RowData>({
       showColumnFilters: true,
       density: "compact",
       columnPinning: { right: ["mrt-row-actions"] },
-      ...rest.initialState,
+      ...initialState,
     },
     state: {
       showGlobalFilter: true,

--- a/epictrack-web/src/components/shared/MasterTrackTable/index.tsx
+++ b/epictrack-web/src/components/shared/MasterTrackTable/index.tsx
@@ -76,21 +76,16 @@ const MasterTrackTable = <TData extends MRT_RowData>({
   onCacheFilters,
   ...rest
 }: MaterialReactTableProps<TData>) => {
-  const [dataState, setDataState] = useState(data);
-  const [dataColumns, setDataColumns] = useState(columns);
-
   const { initialState, state, icons, ...otherProps } = rest;
   const [otherPropsData, setOtherPropsData] = useState(otherProps);
 
   useEffect(() => {
-    setDataColumns(columns);
-    setDataState(data);
     setOtherPropsData(otherProps);
   }, [columns, data]);
 
   const table = useMaterialReactTable({
-    columns: dataColumns,
-    data: dataState,
+    columns: columns,
+    data: data,
     globalFilterFn: "contains",
     enableHiding: false,
     enableGlobalFilter: false,
@@ -212,7 +207,7 @@ const MasterTrackTable = <TData extends MRT_RowData>({
       showColumnFilters: true,
       density: "compact",
       columnPinning: { right: ["mrt-row-actions"] },
-      ...initialState,
+      ...rest.initialState,
     },
     state: {
       showGlobalFilter: true,


### PR DESCRIPTION
https://app.zenhub.com/workspaces/epictrack-63891ea941d309001fa292cf/issues/gh/bcgov/epic.track/2125

Details:
- Take data and columns directly cz they are already stable references, the {...rest} are not 