### PR TITLE
Special field fix

### DIFF
--- a/epictrack-web/src/components/project/ProjectForm/index.tsx
+++ b/epictrack-web/src/components/project/ProjectForm/index.tsx
@@ -94,8 +94,7 @@ export default function ProjectForm({
   const { roles } = useAppSelector((state) => state.user.userDetail);
   const canEdit = roles.includes(ROLES.EDIT);
   const isSpecialFieldLocked = isProponentFieldLocked || isNameFieldLocked;
-  const shouldDisableSpecialField =
-    (!isSpecialFieldLocked || !canEdit) && Boolean(project?.id);
+  const shouldDisableSpecialField = Boolean(project?.id);
   const shouldDisableFormField = !canEdit && Boolean(project?.name);
 
   React.useEffect(() => {

--- a/epictrack-web/src/components/project/ProjectForm/index.tsx
+++ b/epictrack-web/src/components/project/ProjectForm/index.tsx
@@ -96,7 +96,7 @@ export default function ProjectForm({
   const isSpecialFieldLocked = isProponentFieldLocked || isNameFieldLocked;
   const shouldDisableSpecialField =
     (!isSpecialFieldLocked || !canEdit) && Boolean(project?.id);
-  const shouldDisableFormField = !canEdit;
+  const shouldDisableFormField = !canEdit && Boolean(project?.name);
 
   React.useEffect(() => {
     if (setDisableDialogSave) {
@@ -235,12 +235,12 @@ export default function ProjectForm({
             fetchProject();
           }}
           title={project?.name || ""}
-          disabled={!canEdit}
+          disabled={!canEdit || isProponentFieldLocked}
         >
           <ControlledTextField
             name="name"
             placeholder="Project Name"
-            disabled={shouldDisableSpecialField}
+            disabled={shouldDisableSpecialField || isProponentFieldLocked}
             variant="outlined"
             fullWidth
             onBlur={onBlurProjectName}
@@ -254,11 +254,11 @@ export default function ProjectForm({
             fetchProject();
           }}
           options={proponents || []}
-          disabled={!canEdit}
+          disabled={!canEdit || isNameFieldLocked}
         >
           <ControlledSelectV2
             placeholder="Select"
-            disabled={shouldDisableSpecialField}
+            disabled={shouldDisableSpecialField || isNameFieldLocked}
             key={`proponent_select_${formValues.proponent_id}`}
             helperText={errors?.proponent_id?.message?.toString()}
             defaultValue={project?.proponent_id}


### PR DESCRIPTION
#2078 

-Lock special fields when another field is unlocked,
-disable manually changing proponent or project name on unlock