### PR TITLE
Insights Page, Hover states and onclicks for work names

### DIFF
--- a/epictrack-web/src/components/insights/Work/Tabs/General/charts/workListing.tsx
+++ b/epictrack-web/src/components/insights/Work/Tabs/General/charts/workListing.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import { MRT_ColumnDef } from "material-react-table";
 import { showNotification } from "components/shared/notificationProvider";
 import { Work } from "models/work";
@@ -7,8 +7,14 @@ import { searchFilter } from "components/shared/MasterTrackTable/filters";
 import TableFilter from "components/shared/filterSelect/TableFilter";
 import MasterTrackTable from "components/shared/MasterTrackTable";
 import { useGetWorksQuery } from "services/rtkQuery/workInsights";
+import { ETGridTitle } from "components/shared";
+import { useNavigate } from "react-router-dom";
+import { All_WORKS_FILTERS_CACHE_KEY } from "components/work/constants";
+import { ColumnFilter } from "components/shared/MasterTrackTable/type";
+import { useCachedState } from "hooks/useCachedFilters";
 
 const WorkList = () => {
+  const navigate = useNavigate();
   const [phases, setPhases] = React.useState<string[]>([]);
   const [workTypes, setWorkTypes] = React.useState<string[]>([]);
   const [projects, setProjects] = React.useState<string[]>([]);
@@ -16,8 +22,12 @@ const WorkList = () => {
     pageIndex: 0,
     pageSize: 10,
   });
-
+  const [cachedFilters, setCachedFilters] = useCachedState<ColumnFilter[]>(
+    All_WORKS_FILTERS_CACHE_KEY,
+    []
+  );
   const { data, error, isLoading } = useGetWorksQuery();
+  const prevCachedFiltersRef = useRef(cachedFilters);
 
   const works = data || [];
 
@@ -27,6 +37,16 @@ const WorkList = () => {
       pageSize: works.length,
     }));
   }, [works]);
+
+  useEffect(() => {
+    if (
+      JSON.stringify(prevCachedFiltersRef.current) !==
+      JSON.stringify(cachedFilters)
+    ) {
+      navigate("/works");
+    }
+    prevCachedFiltersRef.current = cachedFilters;
+  }, [cachedFilters]);
 
   const codeTypes: { [x: string]: any } = {
     work_type: setWorkTypes,
@@ -57,6 +77,18 @@ const WorkList = () => {
     }
   }, [error]);
 
+  const handleFilterChange = (newFilter: ColumnFilter) => {
+    const newFilters = cachedFilters.map((filter) =>
+      filter.id === newFilter.id ? newFilter : filter
+    );
+
+    if (!newFilters.find((filter) => filter.id === newFilter.id)) {
+      newFilters.push(newFilter);
+    }
+
+    setCachedFilters(newFilters);
+  };
+
   const columns = React.useMemo<MRT_ColumnDef<Work>[]>(
     () => [
       {
@@ -65,6 +97,19 @@ const WorkList = () => {
         size: 300,
         sortingFn: "sortFn",
         filterFn: searchFilter,
+        Cell: ({ row, renderedCellValue }) => (
+          <ETGridTitle
+            to={"#"}
+            enableTooltip
+            tooltip={row.original.title}
+            onClick={(e) => {
+              e.preventDefault();
+              handleFilterChange({ id: "title", value: row.original.title });
+            }}
+          >
+            {renderedCellValue}
+          </ETGridTitle>
+        ),
       },
       {
         accessorKey: "project.name",

--- a/epictrack-web/src/components/insights/Work/Tabs/General/charts/workListing.tsx
+++ b/epictrack-web/src/components/insights/Work/Tabs/General/charts/workListing.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect } from "react";
 import { MRT_ColumnDef } from "material-react-table";
 import { showNotification } from "components/shared/notificationProvider";
 import { Work } from "models/work";
@@ -8,13 +8,8 @@ import TableFilter from "components/shared/filterSelect/TableFilter";
 import MasterTrackTable from "components/shared/MasterTrackTable";
 import { useGetWorksQuery } from "services/rtkQuery/workInsights";
 import { ETGridTitle } from "components/shared";
-import { useNavigate } from "react-router-dom";
-import { All_WORKS_FILTERS_CACHE_KEY } from "components/work/constants";
-import { ColumnFilter } from "components/shared/MasterTrackTable/type";
-import { useCachedState } from "hooks/useCachedFilters";
 
 const WorkList = () => {
-  const navigate = useNavigate();
   const [phases, setPhases] = React.useState<string[]>([]);
   const [workTypes, setWorkTypes] = React.useState<string[]>([]);
   const [projects, setProjects] = React.useState<string[]>([]);
@@ -22,12 +17,7 @@ const WorkList = () => {
     pageIndex: 0,
     pageSize: 10,
   });
-  const [cachedFilters, setCachedFilters] = useCachedState<ColumnFilter[]>(
-    All_WORKS_FILTERS_CACHE_KEY,
-    []
-  );
   const { data, error, isLoading } = useGetWorksQuery();
-  const prevCachedFiltersRef = useRef(cachedFilters);
 
   const works = data || [];
 
@@ -37,16 +27,6 @@ const WorkList = () => {
       pageSize: works.length,
     }));
   }, [works]);
-
-  useEffect(() => {
-    if (
-      JSON.stringify(prevCachedFiltersRef.current) !==
-      JSON.stringify(cachedFilters)
-    ) {
-      navigate("/works");
-    }
-    prevCachedFiltersRef.current = cachedFilters;
-  }, [cachedFilters]);
 
   const codeTypes: { [x: string]: any } = {
     work_type: setWorkTypes,
@@ -77,18 +57,6 @@ const WorkList = () => {
     }
   }, [error]);
 
-  const handleFilterChange = (newFilter: ColumnFilter) => {
-    const newFilters = cachedFilters.map((filter) =>
-      filter.id === newFilter.id ? newFilter : filter
-    );
-
-    if (!newFilters.find((filter) => filter.id === newFilter.id)) {
-      newFilters.push(newFilter);
-    }
-
-    setCachedFilters(newFilters);
-  };
-
   const columns = React.useMemo<MRT_ColumnDef<Work>[]>(
     () => [
       {
@@ -99,13 +67,9 @@ const WorkList = () => {
         filterFn: searchFilter,
         Cell: ({ row, renderedCellValue }) => (
           <ETGridTitle
-            to={"#"}
+            to={`/work-plan?work_id=${row.original.id}`}
             enableTooltip
             tooltip={row.original.title}
-            onClick={(e) => {
-              e.preventDefault();
-              handleFilterChange({ id: "title", value: row.original.title });
-            }}
           >
             {renderedCellValue}
           </ETGridTitle>

--- a/epictrack-web/src/components/insights/Work/Tabs/Partners/charts/WorkList.tsx
+++ b/epictrack-web/src/components/insights/Work/Tabs/Partners/charts/WorkList.tsx
@@ -7,23 +7,14 @@ import { searchFilter } from "components/shared/MasterTrackTable/filters";
 import TableFilter from "components/shared/filterSelect/TableFilter";
 import MasterTrackTable from "components/shared/MasterTrackTable";
 import { useGetWorksWithNationsQuery } from "services/rtkQuery/workInsights";
-import { All_WORKS_FILTERS_CACHE_KEY } from "components/work/constants";
-import { useCachedState } from "hooks/useCachedFilters";
 import { ColumnFilter } from "components/shared/MasterTrackTable/type";
 import { ETGridTitle } from "components/shared";
-import { useNavigate } from "react-router-dom";
 
 const WorkList = () => {
   const [pagination, setPagination] = React.useState({
     pageIndex: 0,
     pageSize: 10,
   });
-  const [cachedFilters, setCachedFilters] = useCachedState<ColumnFilter[]>(
-    All_WORKS_FILTERS_CACHE_KEY,
-    []
-  );
-  const navigate = useNavigate();
-  const prevCachedFiltersRef = useRef(cachedFilters);
   const { data, error, isLoading } = useGetWorksWithNationsQuery();
 
   const works = data || [];
@@ -34,16 +25,6 @@ const WorkList = () => {
       pageSize: works.length,
     }));
   }, [works]);
-
-  useEffect(() => {
-    if (
-      JSON.stringify(prevCachedFiltersRef.current) !==
-      JSON.stringify(cachedFilters)
-    ) {
-      navigate("/works");
-    }
-    prevCachedFiltersRef.current = cachedFilters;
-  }, [cachedFilters]);
 
   useEffect(() => {
     if (error) {
@@ -58,18 +39,6 @@ const WorkList = () => {
   const ministries = useMemo(() => {
     return Array.from(new Set(works.map((w) => w?.ministry?.name)));
   }, [works]);
-
-  const handleFilterChange = (newFilter: ColumnFilter) => {
-    const newFilters = cachedFilters.map((filter) =>
-      filter.id === newFilter.id ? newFilter : filter
-    );
-
-    if (!newFilters.find((filter) => filter.id === newFilter.id)) {
-      newFilters.push(newFilter);
-    }
-
-    setCachedFilters(newFilters);
-  };
 
   const indigenousNations = useMemo(() => {
     const nations = works
@@ -90,15 +59,8 @@ const WorkList = () => {
         filterFn: searchFilter,
         Cell: ({ row, renderedCellValue }) => (
           <ETGridTitle
-            to="#"
+            to={`/work-plan?work_id=${row.original.id}`}
             enableTooltip
-            onClick={(e) => {
-              e.preventDefault();
-              handleFilterChange({
-                id: "title",
-                value: row.original.title,
-              });
-            }}
             titleText={row.original.title}
             tooltip={row.original.title}
           >

--- a/epictrack-web/src/components/insights/Work/Tabs/Partners/charts/WorkList.tsx
+++ b/epictrack-web/src/components/insights/Work/Tabs/Partners/charts/WorkList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from "react";
+import React, { useEffect, useMemo } from "react";
 import { MRT_ColumnDef } from "material-react-table";
 import { showNotification } from "components/shared/notificationProvider";
 import { Work } from "models/work";
@@ -7,7 +7,6 @@ import { searchFilter } from "components/shared/MasterTrackTable/filters";
 import TableFilter from "components/shared/filterSelect/TableFilter";
 import MasterTrackTable from "components/shared/MasterTrackTable";
 import { useGetWorksWithNationsQuery } from "services/rtkQuery/workInsights";
-import { ColumnFilter } from "components/shared/MasterTrackTable/type";
 import { ETGridTitle } from "components/shared";
 
 const WorkList = () => {

--- a/epictrack-web/src/components/insights/Work/Tabs/Partners/charts/WorkList.tsx
+++ b/epictrack-web/src/components/insights/Work/Tabs/Partners/charts/WorkList.tsx
@@ -175,9 +175,11 @@ const WorkList = () => {
         filterSelectOptions: indigenousNations,
         accessorFn: (row) => {
           return (
-            row.indigenous_works
-              ?.map((indigenous_work) => indigenous_work.name)
-              ?.join(", ") ?? ""
+            <ul>
+              {row.indigenous_works?.map((indigenous_work) => (
+                <li key={indigenous_work.id}>{indigenous_work.name}</li>
+              ))}
+            </ul>
           );
         },
         Filter: ({ header, column }) => {

--- a/epictrack-web/src/components/insights/Work/Tabs/Partners/charts/WorkList.tsx
+++ b/epictrack-web/src/components/insights/Work/Tabs/Partners/charts/WorkList.tsx
@@ -63,7 +63,7 @@ const WorkList = () => {
             titleText={row.original.title}
             tooltip={row.original.title}
           >
-            {row.original.title}
+            {renderedCellValue}
           </ETGridTitle>
         ),
       },

--- a/epictrack-web/src/components/insights/Work/Tabs/Partners/charts/WorkList.tsx
+++ b/epictrack-web/src/components/insights/Work/Tabs/Partners/charts/WorkList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import { MRT_ColumnDef } from "material-react-table";
 import { showNotification } from "components/shared/notificationProvider";
 import { Work } from "models/work";
@@ -7,13 +7,23 @@ import { searchFilter } from "components/shared/MasterTrackTable/filters";
 import TableFilter from "components/shared/filterSelect/TableFilter";
 import MasterTrackTable from "components/shared/MasterTrackTable";
 import { useGetWorksWithNationsQuery } from "services/rtkQuery/workInsights";
+import { All_WORKS_FILTERS_CACHE_KEY } from "components/work/constants";
+import { useCachedState } from "hooks/useCachedFilters";
+import { ColumnFilter } from "components/shared/MasterTrackTable/type";
+import { ETGridTitle } from "components/shared";
+import { useNavigate } from "react-router-dom";
 
 const WorkList = () => {
   const [pagination, setPagination] = React.useState({
     pageIndex: 0,
     pageSize: 10,
   });
-
+  const [cachedFilters, setCachedFilters] = useCachedState<ColumnFilter[]>(
+    All_WORKS_FILTERS_CACHE_KEY,
+    []
+  );
+  const navigate = useNavigate();
+  const prevCachedFiltersRef = useRef(cachedFilters);
   const { data, error, isLoading } = useGetWorksWithNationsQuery();
 
   const works = data || [];
@@ -24,6 +34,16 @@ const WorkList = () => {
       pageSize: works.length,
     }));
   }, [works]);
+
+  useEffect(() => {
+    if (
+      JSON.stringify(prevCachedFiltersRef.current) !==
+      JSON.stringify(cachedFilters)
+    ) {
+      navigate("/works");
+    }
+    prevCachedFiltersRef.current = cachedFilters;
+  }, [cachedFilters]);
 
   useEffect(() => {
     if (error) {
@@ -38,6 +58,18 @@ const WorkList = () => {
   const ministries = useMemo(() => {
     return Array.from(new Set(works.map((w) => w?.ministry?.name)));
   }, [works]);
+
+  const handleFilterChange = (newFilter: ColumnFilter) => {
+    const newFilters = cachedFilters.map((filter) =>
+      filter.id === newFilter.id ? newFilter : filter
+    );
+
+    if (!newFilters.find((filter) => filter.id === newFilter.id)) {
+      newFilters.push(newFilter);
+    }
+
+    setCachedFilters(newFilters);
+  };
 
   const indigenousNations = useMemo(() => {
     const nations = works
@@ -56,6 +88,23 @@ const WorkList = () => {
         size: 300,
         sortingFn: "sortFn",
         filterFn: searchFilter,
+        Cell: ({ row, renderedCellValue }) => (
+          <ETGridTitle
+            to="#"
+            enableTooltip
+            onClick={(e) => {
+              e.preventDefault();
+              handleFilterChange({
+                id: "title",
+                value: row.original.title,
+              });
+            }}
+            titleText={row.original.title}
+            tooltip={row.original.title}
+          >
+            {row.original.title}
+          </ETGridTitle>
+        ),
       },
       {
         accessorKey: "ministry.name",
@@ -92,7 +141,7 @@ const WorkList = () => {
       {
         accessorKey: "federal_involvement.name",
         header: "Federal Involvement",
-        size: 200,
+        size: 100,
         filterSelectOptions: federalInvolvements,
         Filter: ({ header, column }) => {
           return (

--- a/epictrack-web/src/components/insights/Work/Tabs/Staff/Charts/workListing.tsx
+++ b/epictrack-web/src/components/insights/Work/Tabs/Staff/Charts/workListing.tsx
@@ -12,21 +12,11 @@ import MasterTrackTable from "components/shared/MasterTrackTable";
 import { WorkStaff } from "models/workStaff";
 import { Role, WorkStaffRole, WorkStaffRoleNames } from "models/role";
 import { useGetWorkStaffsQuery } from "services/rtkQuery/workStaffInsights";
-import { All_WORKS_FILTERS_CACHE_KEY } from "components/work/constants";
-import { useCachedState } from "hooks/useCachedFilters";
-import { ColumnFilter } from "components/shared/MasterTrackTable/type";
-import { useNavigate } from "react-router-dom";
 import { useGetWorksQuery } from "services/rtkQuery/workInsights";
 
 type WorkStaffWithWork = WorkStaff & { work: Work };
 
 const WorkList = () => {
-  const navigate = useNavigate();
-  const [cachedFilters, setCachedFilters] = useCachedState<ColumnFilter[]>(
-    All_WORKS_FILTERS_CACHE_KEY,
-    []
-  );
-  const prevCachedFiltersRef = useRef(cachedFilters);
   const [workTypes, setWorkTypes] = React.useState<string[]>([]);
   const [leads, setLeads] = React.useState<string[]>([]);
   const [teams, setTeams] = React.useState<string[]>([]);
@@ -64,16 +54,6 @@ const WorkList = () => {
       }));
     }
   }, [workStaffs, works]);
-
-  useEffect(() => {
-    if (
-      JSON.stringify(prevCachedFiltersRef.current) !==
-      JSON.stringify(cachedFilters)
-    ) {
-      navigate("/works");
-    }
-    prevCachedFiltersRef.current = cachedFilters;
-  }, [cachedFilters]);
 
   const officerAnalysts = React.useMemo(() => {
     if (!workStaffs) return [];
@@ -159,18 +139,6 @@ const WorkList = () => {
     setWorkRoles(cols);
   }, [workStaffs]);
 
-  const handleFilterChange = (newFilter: ColumnFilter) => {
-    const newFilters = cachedFilters.map((filter) =>
-      filter.id === newFilter.id ? newFilter : filter
-    );
-
-    if (!newFilters.find((filter) => filter.id === newFilter.id)) {
-      newFilters.push(newFilter);
-    }
-
-    setCachedFilters(newFilters);
-  };
-
   const codeTypes: { [x: string]: any } = {
     work_type: setWorkTypes,
     eao_team: setTeams,
@@ -204,14 +172,7 @@ const WorkList = () => {
         Cell: ({ row, renderedCellValue }) => {
           return (
             <ETGridTitle
-              to="#"
-              onClick={(e) => {
-                e.preventDefault();
-                handleFilterChange({
-                  id: "title",
-                  value: row.original.work.title,
-                });
-              }}
+              to={`/work-plan?work_id=${row.original.work.id}`}
               titleText={row.original.work.title}
               enableTooltip
               tooltip={row.original.work.title}

--- a/epictrack-web/src/components/insights/Work/Tabs/Staff/Charts/workListing.tsx
+++ b/epictrack-web/src/components/insights/Work/Tabs/Staff/Charts/workListing.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect } from "react";
 import { MRT_ColumnDef } from "material-react-table";
 import { useAppSelector } from "hooks";
 import { hasPermission } from "components/shared/restricted";

--- a/epictrack-web/src/components/insights/Work/Tabs/Staff/Charts/workListing.tsx
+++ b/epictrack-web/src/components/insights/Work/Tabs/Staff/Charts/workListing.tsx
@@ -177,7 +177,7 @@ const WorkList = () => {
               enableTooltip
               tooltip={row.original.work.title}
             >
-              {row.original.work.title}
+              {renderedCellValue}
             </ETGridTitle>
           );
         },

--- a/epictrack-web/src/components/work/WorkList.tsx
+++ b/epictrack-web/src/components/work/WorkList.tsx
@@ -116,7 +116,7 @@ const WorkList = () => {
             tooltip={row.original.title}
             titleText={row.original.title}
           >
-            {renderedCellValue}
+            {row.original.title}
           </ETGridTitle>
         ),
         sortingFn: "sortFn",


### PR DESCRIPTION
#2104 

Made the following changes:
    staff: work name should be clickable
    staff: hover needed on truncated text
    staff: team & lead should have fixed width columns (same as on all works)
    staff: officer Analyst should not be blue
    general: work name should be clickable
    general: hover needed on truncated text
    partners: work name should be clickable
    partners: hover needed on truncated text
    partners: hoverstate for nations column needs to 'return' separated (like a bullet list) instead of comma separated
    partners: federal involvement should have fixed width columns (same as on all works)
