### PR TITLE
Reorder work staff columns

### DIFF
--- a/epictrack-web/src/components/work/workStaff/WorkStaffList.tsx
+++ b/epictrack-web/src/components/work/workStaff/WorkStaffList.tsx
@@ -129,13 +129,6 @@ const WorkStaffList = () => {
   const columns = React.useMemo<MRT_ColumnDef<WorkStaff>[]>(
     () => [
       {
-        accessorKey: "project.name",
-        header: "Project",
-        enableHiding: false,
-        filterVariant: "multi-select",
-        filterSelectOptions: projectFilter,
-      },
-      {
         accessorKey: "title",
         header: "Work Title",
         filterVariant: "multi-select",
@@ -153,6 +146,13 @@ const WorkStaffList = () => {
             </ETGridTitle>
           );
         },
+      },
+      {
+        accessorKey: "project.name",
+        header: "Project",
+        enableHiding: false,
+        filterVariant: "multi-select",
+        filterSelectOptions: projectFilter,
       },
       {
         accessorFn: (row: WorkStaff) =>


### PR DESCRIPTION
#2176 

-Requested by Dinesh: Reorder work staff grid move work title to first column
