### PR TITLE
Prevent issue start date being after earliest update

### DIFF
--- a/epictrack-api/src/api/services/work_issues.py
+++ b/epictrack-api/src/api/services/work_issues.py
@@ -118,7 +118,7 @@ class WorkIssuesService:  # pylint: disable=too-many-public-methods
             if new_data.get('start_date').timestamp() > new_data.get('expected_resolution_date').timestamp():
                 raise BadRequestError('expected resolution date cannot be before the start date')
 
-        earliest_issue_update_date = min([update.posted_date for update in work_issue_db.updates])
+        earliest_issue_update_date = min(update.posted_date for update in work_issue_db.updates)
         if new_data.get('start_date').timestamp() > earliest_issue_update_date.timestamp():
             raise BadRequestError('issue start date cannot be after an update date')
 

--- a/epictrack-web/src/components/workPlan/issues/Forms/EditIssue.tsx
+++ b/epictrack-web/src/components/workPlan/issues/Forms/EditIssue.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import * as yup from "yup";
 import { yupResolver } from "@hookform/resolvers/yup";
@@ -13,6 +13,7 @@ import { EditIssueForm } from "../types";
 import moment from "moment";
 import ControlledDatePicker from "../../../shared/controlledInputComponents/ControlledDatePicker";
 import { ETFormLabel } from "../../../shared";
+import dayjs from "dayjs";
 
 const InfoIcon: React.FC<IconProps> = Icons["InfoIcon"];
 
@@ -39,6 +40,19 @@ const EditIssue = () => {
     },
     mode: "onSubmit",
   });
+
+  const maxStartDate = useMemo(() => {
+    if (!issueToEdit) {
+      return undefined;
+    }
+
+    // find the min date of updates
+    const updatesPostedDates = issueToEdit.updates.map((update) =>
+      moment(update.posted_date)
+    );
+    const minPostedDate = moment.min(updatesPostedDates).toDate();
+    return dayjs(minPostedDate);
+  }, [issueToEdit]);
 
   const { handleSubmit, watch } = methods;
 
@@ -131,7 +145,12 @@ const EditIssue = () => {
         </Grid>
         <Grid item xs={6}>
           <ETFormLabel required>Start Date</ETFormLabel>
-          <ControlledDatePicker name="start_date" />
+          <ControlledDatePicker
+            name="start_date"
+            datePickerProps={{
+              maxDate: maxStartDate,
+            }}
+          />
         </Grid>
         <Grid item xs={6}>
           <ETFormLabel required>Expected Resolution Date</ETFormLabel>


### PR DESCRIPTION
https://app.zenhub.com/workspaces/epictrack-63891ea941d309001fa292cf/issues/gh/bcgov/epic.track/2105

Details:
- Add backend check
- Add front end restriction