### PR TITLE
Fix showing stale status alert for completed works

### DIFF
--- a/epictrack-web/src/components/workPlan/status/StatusView/index.tsx
+++ b/epictrack-web/src/components/workPlan/status/StatusView/index.tsx
@@ -13,7 +13,7 @@ import { hasPermission } from "components/shared/restricted";
 import { ROLES } from "constants/application-constant";
 
 const StatusView = () => {
-  const { statuses, team } = React.useContext(WorkplanContext);
+  const { statuses, team, work } = React.useContext(WorkplanContext);
   const { setShowStatusForm } = React.useContext(StatusContext);
 
   const { email, roles: currentRoles } = useAppSelector(
@@ -31,9 +31,9 @@ const StatusView = () => {
     setShowStatusForm(true);
   };
 
-  const statusOutOfDate = isStatusOutOfDate(
-    statuses.find((status) => status.is_approved)
-  );
+  const latestApprovedStatus = statuses.find((status) => status.is_approved);
+  const statusOutOfDate =
+    !work?.is_complete && isStatusOutOfDate(latestApprovedStatus);
 
   return (
     <>


### PR DESCRIPTION
https://app.zenhub.com/workspaces/epictrack-63891ea941d309001fa292cf/issues/gh/bcgov/epic.track/2266

Details:
- Add check if work is not complete then check  if stale status