### PR TITLE
Make table in resource forecast scrollable

### DIFF
--- a/epictrack-web/src/components/reports/resourceForecast/ResourceForecast.tsx
+++ b/epictrack-web/src/components/reports/resourceForecast/ResourceForecast.tsx
@@ -457,6 +457,17 @@ export default function ResourceForecast() {
               paddingRight: "2px",
             },
           }}
+          muiTableContainerProps={{
+            sx: {
+              maxHeight: {
+                xs: "calc(100vh - 200px)",
+                sm: "calc(100vh - 250px)",
+                md: "calc(100vh - 300px)",
+                lg: "calc(100vh - 350px)",
+                xl: "calc(100vh - 400px)",
+              },
+            },
+          }}
           onColumnFiltersChange={setColumnFilters}
           onColumnVisibilityChange={setColumnVisibility}
           onGlobalFilterChange={setGlobalFilter}


### PR DESCRIPTION
https://app.zenhub.com/workspaces/epictrack-63891ea941d309001fa292cf/issues/gh/bcgov/epic.track/2066

Details:
- add a maximum height to table depending on screen size