### PR TITLE
Fix toggle button status in edit issue modal

### DIFF
--- a/epictrack-web/src/components/workPlan/issues/Forms/EditIssue.tsx
+++ b/epictrack-web/src/components/workPlan/issues/Forms/EditIssue.tsx
@@ -33,8 +33,8 @@ const EditIssue = () => {
     resolver: yupResolver(schema),
     defaultValues: {
       title: issueToEdit?.title || "",
-      is_active: issueToEdit?.is_active || true,
-      is_high_priority: issueToEdit?.is_high_priority || false,
+      is_active: Boolean(issueToEdit?.is_active),
+      is_high_priority: Boolean(issueToEdit?.is_high_priority),
       start_date: issueToEdit?.start_date || "",
       expected_resolution_date: issueToEdit?.expected_resolution_date || "",
     },


### PR DESCRIPTION
https://app.zenhub.com/workspaces/epictrack-63891ea941d309001fa292cf/issues/gh/bcgov/epic.track/2258

Details:
- Take the status value from the IssueToEdit in the EditIssue modal