### PR TITLE
Fix work form save bug when simple_name is null (#2313)

### DIFF
--- a/epictrack-web/src/components/work/Dialog/index.tsx
+++ b/epictrack-web/src/components/work/Dialog/index.tsx
@@ -35,6 +35,14 @@ export const WorkDialog = ({
     if (!workId) return;
     try {
       const response = await workService.getById(String(workId));
+
+      const fetchedWork = response.data;
+
+      // set simple_title to empty string if it is null
+      if (fetchedWork.simple_title === null) {
+        fetchedWork.simple_title = "";
+      }
+
       setWork(response.data);
     } catch (error) {
       showNotification("Could not load Work", {
@@ -42,7 +50,7 @@ export const WorkDialog = ({
       });
     }
   };
-
+  
   const createWork = async (data: any) => {
     await workService.create(data);
   };


### PR DESCRIPTION
The issue was that the Minister's Designation for Aspen Solar and Energy Storage somehow has a simple_name of null instead of an empty string like the other works do by default. 

In components/work/WorkForm/index.tsx there is a format check using _yup_ schema which has this requirement:

` simple_title: yup.string()`

This check fails when simple_string is null, which prevented the form from submitting altogether. The fix was when fetching the work data to manually set simple_name to an empty string if it was null.