### PR TITLE
encode project names when checking existance

### DIFF
--- a/epictrack-web/src/services/indigenousNationService/indigenousNationService.ts
+++ b/epictrack-web/src/services/indigenousNationService/indigenousNationService.ts
@@ -37,9 +37,10 @@ class IndigenousNationService implements ServiceBase {
     );
   }
   async checkIndigenousNationExists(name: string, id: number) {
+    const encodedName = encodeURIComponent(name);
     return await http.GetRequest(
       Endpoints.IndigenousNations.INDIGENOUS_NATIONS +
-        `/exists?name=${name}${id ? "&indigenous_nation_id=" + id : ""}`
+        `/exists?name=${encodedName}${id ? "&indigenous_nation_id=" + id : ""}`
     );
   }
 }

--- a/epictrack-web/src/services/projectService/projectService.ts
+++ b/epictrack-web/src/services/projectService/projectService.ts
@@ -37,9 +37,10 @@ class ProjectService implements ServiceBase {
   }
 
   async checkProjectExists(name: string, id: number) {
+    const encodedName = encodeURIComponent(name);
     return await http.GetRequest(
       Endpoints.Projects.PROJECTS +
-        `/exists?name=${name}${id ? "&project_id=" + id : ""}`
+        `/exists?name=${encodedName}${id ? "&project_id=" + id : ""}`
     );
   }
 

--- a/epictrack-web/src/services/proponentService/proponentService.ts
+++ b/epictrack-web/src/services/proponentService/proponentService.ts
@@ -31,9 +31,10 @@ class ProponentService implements ServiceBase {
   }
 
   async checkProponentExists(name: string, id: number) {
+    const encodedName = encodeURIComponent(name);
     return await http.GetRequest(
       Endpoints.Proponents.PROPONENTS +
-        `/exists?name=${name}${id ? "&proponent_id=" + id : ""}`
+        `/exists?name=${encodedName}${id ? "&proponent_id=" + id : ""}`
     );
   }
 }

--- a/epictrack-web/src/services/workService/workService.ts
+++ b/epictrack-web/src/services/workService/workService.ts
@@ -35,9 +35,10 @@ class WorkService implements ServiceBase {
   }
 
   async checkWorkExists(title: string, id?: string) {
+    const encodedTitle = encodeURIComponent(title);
     return await http.GetRequest(
       Endpoints.Works.WORKS +
-        `/exists?title=${title}${id ? "&work_id=" + id : ""}`
+        `/exists?title=${encodedTitle}${id ? "&work_id=" + id : ""}`
     );
   }
 


### PR DESCRIPTION
#2350 

Currently if a project name includes a '&' such as 'Jedney Gas Plant & Pipeline Expansion' when we check existance we get a 400 with an error "message": "{\" Pipeline Expansion\": [\"Unknown field.\"]}"}