### PR TITLE
fix double click to get back to workplan listing page

### DIFF
--- a/epictrack-web/src/hooks/useRouterLocationStateForHelpPage.tsx
+++ b/epictrack-web/src/hooks/useRouterLocationStateForHelpPage.tsx
@@ -20,6 +20,7 @@ const useRouterLocationStateForHelpPage = (
 
     navigate(`${location.pathname}${location.search}`, {
       state: { helpPageTags: newtags },
+      replace: true, // modify current entry in history stack rather than adding duplicate
     });
   }, dependencies);
 };


### PR DESCRIPTION
prevent adding a duplicate entry into history stack when navigating the workplan tabs