### PR TITLE
TRACK-31: create work error

### DIFF
--- a/epictrack-api/src/api/services/work.py
+++ b/epictrack-api/src/api/services/work.py
@@ -476,7 +476,6 @@ class WorkService:  # pylint: disable=too-many-public-methods
             cls.update_work_staff(work_staff.id, update_data, commit=False)
 
         upserted_work_staff = cls.upsert_work_staff(work_id, data, commit=False)
-        db.session.commit()
         return upserted_work_staff
 
     @classmethod


### PR DESCRIPTION
https://eao-dst.atlassian.net/jira/software/c/projects/TRACK/boards/10?selectedIssue=TRACK-31
change create work to only have a single transaction to prevent errors of partial completion