### PR TITLE
TRACK-190: fix setting event actual when previous event deleted

### DIFF
--- a/epictrack-api/src/api/services/event.py
+++ b/epictrack-api/src/api/services/event.py
@@ -1014,6 +1014,7 @@ class EventService:
             )
             .filter(
                 Event.is_active.is_(True),
+                Event.is_deleted.is_(False),
                 Event.work_id == work_id,
                 EventConfiguration.is_active.is_(True),
             )


### PR DESCRIPTION
https://eao-dst.atlassian.net/jira/software/c/projects/TRACK/boards/10?selectedIssue=TRACK-190

When event actual date is set we perform checks to see if previous events actual date are set. Fixed bug where we were checking previous event actual date was set even if the event had been deleted 