### PR TITLE
TRACK-249: Delete request from DB required query filter to be setup

### DIFF
--- a/epictrack-api/src/api/models/work_issues.py
+++ b/epictrack-api/src/api/models/work_issues.py
@@ -46,8 +46,11 @@ class WorkIssues(BaseModelVersioned):
 
     @classmethod
     def list_issues_for_work_id(cls, work_id) -> List[WorkIssues]:
-        """List all WorkIssues sorted by start_date."""
-        query = WorkIssues.query.filter(cls.work_id == work_id).order_by(
+        """List all WorkIssues sorted by start_date, filtering out WorkIssues marked as deleted in the DB"""
+        query = WorkIssues.query.filter(
+            cls.work_id == work_id,
+            cls.is_deleted.is_(False)
+            ).order_by(
             cls.start_date.desc()
         )
         return query.all()

--- a/epictrack-api/src/api/models/work_issues.py
+++ b/epictrack-api/src/api/models/work_issues.py
@@ -50,7 +50,7 @@ class WorkIssues(BaseModelVersioned):
         query = WorkIssues.query.filter(
             cls.work_id == work_id,
             cls.is_deleted.is_(False)
-            ).order_by(
+        ).order_by(
             cls.start_date.desc()
-            )
+        )
         return query.all()

--- a/epictrack-api/src/api/models/work_issues.py
+++ b/epictrack-api/src/api/models/work_issues.py
@@ -52,5 +52,5 @@ class WorkIssues(BaseModelVersioned):
             cls.is_deleted.is_(False)
             ).order_by(
             cls.start_date.desc()
-        )
+            )
         return query.all()


### PR DESCRIPTION
EAO team wanted an issue deleted. There is an "is_deleted"  flag in the DB but the API wasn't filtering those issues out.