### PR TITLE
Fixed Sqlalchemy warning regarding cartesian product

### DIFF
--- a/epictrack-api/src/api/reports/thirty_sixty_ninety_report.py
+++ b/epictrack-api/src/api/reports/thirty_sixty_ninety_report.py
@@ -363,7 +363,9 @@ class ThirtySixtyNinetyReport(ReportFactory):
 
     def _get_valid_event_ids(self, start_date, end_date):
         """Find and return set of valid decision or high priority event ids"""
-        valid_events = db.session.query(Event).filter(
+        valid_events = db.session.query(Event).join(
+            Work, Work.id == Event.work_id
+        ).filter(
             func.coalesce(Event.actual_date, Event.anticipated_date).between(
                 start_date.date(), end_date.date()
             ),


### PR DESCRIPTION
Removes the 30 60 90 report's SAWarning by properly declaring the join between the event and work