### PR TITLE
fix: Pass work_id when setting project state on work completion (Track-783)

### DIFF
--- a/epictrack-api/src/api/actions/set_project_state.py
+++ b/epictrack-api/src/api/actions/set_project_state.py
@@ -49,5 +49,5 @@ class SetProjectState(ActionFactory):
             "field_type": FieldTypeEnum.INTEGER.value,
         }
         SpecialFieldService.create_special_field_entry(
-            project_state_special_field_data, commit=False
+            project_state_special_field_data, commit=False, work_id=source_event.work_id
         )

--- a/epictrack-api/tests/unit/apis/test_event_templates.py
+++ b/epictrack-api/tests/unit/apis/test_event_templates.py
@@ -74,9 +74,9 @@ class TestEventTemplateUploadAuth:
     def test_upload_without_extended_edit_role_returns_403(self, client, jwt, app):
         """A valid token without extended_edit must receive 403."""
         with app.app_context():
-            # manage_user_role has only 'manage_users' — no 'extended_edit'
+            # viewer has only 'view' — no 'extended_edit'
             headers = factory_auth_header(
-                jwt=jwt, claims=TestJwtClaims.manage_user_role
+                jwt=jwt, claims=TestJwtClaims.viewer
             )
             data = {"event_template": (_minimal_template_file(), "template.xlsx")}
             response = client.post(


### PR DESCRIPTION
SetProjectState creates a PROJECT special field entry during final-phase completion but did not pass work_id. SpecialFieldService._check_auth only grants a work team member access when a work_id is available, so completing the last phase raised a 403 for team members lacking the global EXTENDED_EDIT role. Pass source_event.work_id, mirroring SetWorkState.

Ref #Track-783